### PR TITLE
Clip system rewrite

### DIFF
--- a/JustDanceEditor.Converter/Converters/Audio/AudioConverter.cs
+++ b/JustDanceEditor.Converter/Converters/Audio/AudioConverter.cs
@@ -4,6 +4,7 @@ using JustDanceEditor.Converter.Helpers;
 using JustDanceEditor.Converter.Resources;
 using JustDanceEditor.Converter.UbiArt;
 using JustDanceEditor.Converter.UbiArt.Tapes;
+using JustDanceEditor.Converter.UbiArt.Tapes.Clips;
 
 namespace JustDanceEditor.Converter.Converters.Audio;
 public static class AudioConverter
@@ -30,7 +31,7 @@ public static class AudioConverter
     {
         Console.WriteLine("Converting audio files...");
         Stopwatch stopwatch = Stopwatch.StartNew();
-        MainSequenceClip[] audioClips = GetAudioClips(convert.SongData.MainSequence);
+        SoundSetClip[] audioClips = GetAudioClips(convert.SongData.MainSequence.Clips);
 
         ConvertAudioFiles(convert, audioClips);
         string newMainSongPath = ConvertMainSong(convert);
@@ -40,14 +41,14 @@ public static class AudioConverter
         MergeAudioFiles(convert, audioClips, newMainSongPath);
     }
 
-    private static MainSequenceClip[] GetAudioClips(MainSequence mainSequence)
+    private static SoundSetClip[] GetAudioClips(IClip[] clips)
     {
-        return mainSequence.Clips.Where(s => s.__class == "SoundSetClip").ToArray();
+        return clips.OfType<SoundSetClip>().ToArray();
     }
 
-    private static void ConvertAudioFiles(ConvertUbiArtToUnity convert, MainSequenceClip[] audioClips)
+    private static void ConvertAudioFiles(ConvertUbiArtToUnity convert, SoundSetClip[] audioClips)
     {
-        foreach (MainSequenceClip audioVibrationClip in audioClips)
+        foreach (SoundSetClip audioVibrationClip in audioClips)
         {
             string fileName = Path.GetFileNameWithoutExtension(audioVibrationClip.SoundSetPath);
             string wavPath = Path.Combine(convert.CacheFolder, "audio", "amb", $"{fileName}.wav.ckd");
@@ -71,7 +72,7 @@ public static class AudioConverter
             : Directory.GetFiles(Path.Combine(convert.CacheFolder, "audio")).Where(x => x.EndsWith(".wav.ckd")).First();
     }
 
-    private static void MergeAudioFiles(ConvertUbiArtToUnity convert, MainSequenceClip[] audioClips, string newMainSongPath)
+    private static void MergeAudioFiles(ConvertUbiArtToUnity convert, SoundSetClip[] audioClips, string newMainSongPath)
     {
         Console.WriteLine("Merging audio files...");
         Stopwatch stopwatch = Stopwatch.StartNew();
@@ -82,7 +83,7 @@ public static class AudioConverter
         // Process each audio clip
         for (int i = 0; i < audioClips.Length; i++)
         {
-            MainSequenceClip clip = audioClips[i];
+            SoundSetClip clip = audioClips[i];
             string fileName = Path.GetFileNameWithoutExtension(clip.SoundSetPath);
             string wavPath = Path.Combine(convert.TempAudioFolder, $"{fileName}.wav");
 

--- a/JustDanceEditor.Converter/Converters/Bundles/MapPackageBundleGenerator.cs
+++ b/JustDanceEditor.Converter/Converters/Bundles/MapPackageBundleGenerator.cs
@@ -9,6 +9,7 @@ using JustDanceEditor.Converter.Unity;
 using SixLabors.ImageSharp.PixelFormats;
 using SixLabors.ImageSharp;
 using TextureConverter.TextureConverterHelpers;
+using JustDanceEditor.Converter.UbiArt.Tapes.Clips;
 
 namespace JustDanceEditor.Converter.Converters.Bundles;
 public static class MapPackageBundleGenerator
@@ -206,8 +207,11 @@ public static class MapPackageBundleGenerator
         karaokeArray.Children.Clear();
 
         // For each clip in the karaoke file, create a new KaraokeClipContainer
-        foreach (KaraokeClip clip in convert.SongData.KTape.Clips)
+        foreach (IClip iClip in convert.SongData.KTape.Clips)
         {
+            if (iClip is not KaraokeClip clip)
+                continue;
+
             // Create a new KaraokeClipContainer
             AssetTypeValueField newContainer = ValueBuilder.DefaultValueFieldFromArrayTemplate(karaokeArray);
             AssetTypeValueField karaokeClip = newContainer["KaraokeClip"];
@@ -517,12 +521,12 @@ public static class MapPackageBundleGenerator
         }
 
         // Add the clips from the dance tape
-        foreach (MotionClip clip in convert.SongData.DTape.Clips)
+        foreach (IClip iClip in convert.SongData.DTape.Clips)
         {
             // If the clip is a GoldEffectClip, add it to the GoldEffectClips array
-            switch (clip.__class)
+            switch (iClip)
             {
-                case "GoldEffectClip":
+                case GoldEffectClip clip:
                     AssetTypeValueField newGoldEffectClip = ValueBuilder.DefaultValueFieldFromArrayTemplate(goldEffectClipsArray);
 
                     newGoldEffectClip["StartTime"].AsInt = clip.StartTime;
@@ -534,7 +538,7 @@ public static class MapPackageBundleGenerator
 
                     goldEffectClipsArray.Children.Add(newGoldEffectClip);
                     break;
-                case "PictogramClip":
+                case PictogramClip clip:
                     AssetTypeValueField newPictoClip = ValueBuilder.DefaultValueFieldFromArrayTemplate(pictoClips);
 
                     newPictoClip["StartTime"].AsInt = clip.StartTime;
@@ -547,7 +551,7 @@ public static class MapPackageBundleGenerator
 
                     pictoClips.Children.Add(newPictoClip);
                     break;
-                case "MotionClip":
+                case MotionClip clip:
                     // Create a new MotionClip
                     AssetTypeValueField newMotionClip = ValueBuilder.DefaultValueFieldFromArrayTemplate(motionClipsArray);
 
@@ -576,25 +580,25 @@ public static class MapPackageBundleGenerator
                     break;
 
                 default:
-                    Console.WriteLine($"Unknown clip type: {clip.__class}");
+                    Console.WriteLine($"Unknown clip type: {iClip.__class}");
                     break;
             }
         }
 
         // Add the clips from the mainsequence tape
-        foreach (MainSequenceClip clip in convert.SongData.MainSequence.Clips)
+        foreach (IClip iClip in convert.SongData.MainSequence.Clips)
         {
+            if (iClip is not HideUserInterfaceClip clip)
+                continue;
+
             // If the clip is a HideUserInterfaceClip, add it to the HideHudClips array
-            if (clip.__class == "HideUserInterfaceClip")
-            {
-                AssetTypeValueField newHideHudClip = ValueBuilder.DefaultValueFieldFromArrayTemplate(hideHudClips);
+            AssetTypeValueField newHideHudClip = ValueBuilder.DefaultValueFieldFromArrayTemplate(hideHudClips);
 
-                newHideHudClip["StartTime"].AsInt = clip.StartTime;
-                newHideHudClip["Duration"].AsInt = clip.Duration;
-                newHideHudClip["IsActive"].AsUInt = (uint)clip.IsActive;
+            newHideHudClip["StartTime"].AsInt = clip.StartTime;
+            newHideHudClip["Duration"].AsInt = clip.Duration;
+            newHideHudClip["IsActive"].AsUInt = (uint)clip.IsActive;
 
-                hideHudClips.Children.Add(newHideHudClip);
-            }
+            hideHudClips.Children.Add(newHideHudClip);
         }
 
         // Store all changes

--- a/JustDanceEditor.Converter/Converters/ConvertUbiArtToUnity.cs
+++ b/JustDanceEditor.Converter/Converters/ConvertUbiArtToUnity.cs
@@ -7,6 +7,7 @@ using JustDanceEditor.Converter.Converters.Images;
 using JustDanceEditor.Converter.Converters.Bundles;
 using System.Diagnostics;
 using JustDanceEditor.Converter.UbiArt.Tapes.Clips;
+using JustDanceEditor.Converter.Helpers;
 
 namespace JustDanceEditor.Converter.Converters;
 
@@ -137,6 +138,7 @@ public class ConvertUbiArtToUnity
 
         JsonSerializerOptions options = new();
         options.Converters.Add(new ClipConverter());
+        options.Converters.Add(new IntBoolConverter());
 
         Console.WriteLine("Loading KTape");
         SongData.KTape = JsonSerializer.Deserialize<KaraokeTape>(File.ReadAllText(Path.Combine(TimelineFolder, $"{SongData.Name}_tml_karaoke.ktape.ckd")).Replace("\0", ""), options)!;

--- a/JustDanceEditor.Converter/Converters/ConvertUbiArtToUnity.cs
+++ b/JustDanceEditor.Converter/Converters/ConvertUbiArtToUnity.cs
@@ -6,6 +6,7 @@ using JustDanceEditor.Converter.Converters.Audio;
 using JustDanceEditor.Converter.Converters.Images;
 using JustDanceEditor.Converter.Converters.Bundles;
 using System.Diagnostics;
+using JustDanceEditor.Converter.UbiArt.Tapes.Clips;
 
 namespace JustDanceEditor.Converter.Converters;
 
@@ -115,7 +116,6 @@ public class ConvertUbiArtToUnity
 
     void LoadSongData()
     {
-
         // Load in the song data
         Console.WriteLine("Loading song info...");
 
@@ -135,14 +135,17 @@ public class ConvertUbiArtToUnity
             " which is not officially supported. The conversion might not work as expected." :
             "");
 
+        JsonSerializerOptions options = new();
+        options.Converters.Add(new ClipConverter());
+
         Console.WriteLine("Loading KTape");
-        SongData.KTape = JsonSerializer.Deserialize<KaraokeTape>(File.ReadAllText(Path.Combine(TimelineFolder, $"{SongData.Name}_tml_karaoke.ktape.ckd")).Replace("\0", ""))!;
+        SongData.KTape = JsonSerializer.Deserialize<KaraokeTape>(File.ReadAllText(Path.Combine(TimelineFolder, $"{SongData.Name}_tml_karaoke.ktape.ckd")).Replace("\0", ""), options)!;
         Console.WriteLine("Loading DTape");
-        SongData.DTape = JsonSerializer.Deserialize<DanceTape>(File.ReadAllText(Path.Combine(TimelineFolder, $"{SongData.Name}_tml_dance.dtape.ckd")).Replace("\0", ""))!;
+        SongData.DTape = JsonSerializer.Deserialize<DanceTape>(File.ReadAllText(Path.Combine(TimelineFolder, $"{SongData.Name}_tml_dance.dtape.ckd")).Replace("\0", ""), options)!;
         Console.WriteLine("Loading MTrack");
-        SongData.MTrack = JsonSerializer.Deserialize<MusicTrack>(File.ReadAllText(Path.Combine(CacheFolder, "audio", $"{SongData.Name}_musictrack.tpl.ckd")).Replace("\0", ""))!;
+        SongData.MTrack = JsonSerializer.Deserialize<MusicTrack>(File.ReadAllText(Path.Combine(CacheFolder, "audio", $"{SongData.Name}_musictrack.tpl.ckd")).Replace("\0", ""), options)!;
         Console.WriteLine("Loading MainSequence");
-        SongData.MainSequence = JsonSerializer.Deserialize<MainSequence>(File.ReadAllText(Path.Combine(CacheFolder, "cinematics", $"{SongData.Name}_mainsequence.tape.ckd")).Replace("\0", ""))!;
+        SongData.MainSequence = JsonSerializer.Deserialize<MainSequence>(File.ReadAllText(Path.Combine(CacheFolder, "cinematics", $"{SongData.Name}_mainsequence.tape.ckd")).Replace("\0", ""), options)!;
         Console.WriteLine("Loading SongDesc");
         SongData.SongDesc = JsonSerializer.Deserialize<SongDesc>(File.ReadAllText(Path.Combine(CacheFolder, "songdesc.tpl.ckd")).Replace("\0", ""))!;
 

--- a/JustDanceEditor.Converter/Helpers/Audio.cs
+++ b/JustDanceEditor.Converter/Helpers/Audio.cs
@@ -31,9 +31,22 @@ public static class Audio
         // Create a list to hold the SampleProviders
         List<ISampleProvider> sampleProviders = [];
 
+        bool anyExists = false;
+
         // Loop through the audio files
         foreach ((string path, float startTime) in audioFiles)
         {
+            // If the file doesn't exist, skip it, but throw a big red warning
+            if (!File.Exists(path))
+            {
+                Console.ForegroundColor = ConsoleColor.Red;
+                Console.WriteLine($"File {path} does not exist!");
+                Console.ResetColor();
+                continue;
+            }
+
+            anyExists = true;
+
             // Read in the next file with the correct start time
             AudioFileReader reader = new(path);
 
@@ -45,6 +58,10 @@ public static class Audio
             // Add the reader to the list of SampleProviders
             sampleProviders.Add(offsetSampleProvider);
         }
+
+        // If no files exist, return
+        if (!anyExists)
+            return;
 
         // Create a mixer with the SampleProviders
         MixingSampleProvider mixer = new(sampleProviders[0].WaveFormat);

--- a/JustDanceEditor.Converter/Helpers/IntBoolConverter.cs
+++ b/JustDanceEditor.Converter/Helpers/IntBoolConverter.cs
@@ -1,0 +1,23 @@
+﻿using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace JustDanceEditor.Converter.Helpers;
+
+public class IntBoolConverter : JsonConverter<int>
+{
+    public override int Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+    {
+        return reader.TokenType switch
+        {
+            JsonTokenType.False => 0,
+            JsonTokenType.True => 1,
+            JsonTokenType.Number when reader.TryGetInt32(out int intValue) => intValue,
+            _ => throw new JsonException("Unexpected token type")
+        };
+    }
+
+    public override void Write(Utf8JsonWriter writer, int value, JsonSerializerOptions options)
+    {
+        writer.WriteNumberValue(value);
+    }
+}

--- a/JustDanceEditor.Converter/JustDanceEditor.Converter.csproj
+++ b/JustDanceEditor.Converter/JustDanceEditor.Converter.csproj
@@ -27,6 +27,10 @@
 		<ProjectReference Include="..\TextureConverter\TextureConverter.csproj" />
 	</ItemGroup>
 
+	<ItemGroup>
+	  <Folder Include="Helpers\CustomJsonParsers\" />
+	</ItemGroup>
+
 	<Target Name="CopyFilesAfterBuild" AfterTargets="AfterBuild">
 		<Copy SourceFiles="$(SolutionDir)TexToolWrap\PVRTexLib\Windows_x86_64\PVRTexLib.dll" DestinationFolder="$(TargetDir)" />
 		<Copy SourceFiles="$(SolutionDir)TexToolWrap\ispc\win64\ispc_texcomp.dll" DestinationFolder="$(TargetDir)" />

--- a/JustDanceEditor.Converter/JustDanceEditor.Converter.csproj
+++ b/JustDanceEditor.Converter/JustDanceEditor.Converter.csproj
@@ -27,10 +27,6 @@
 		<ProjectReference Include="..\TextureConverter\TextureConverter.csproj" />
 	</ItemGroup>
 
-	<ItemGroup>
-	  <Folder Include="Helpers\CustomJsonParsers\" />
-	</ItemGroup>
-
 	<Target Name="CopyFilesAfterBuild" AfterTargets="AfterBuild">
 		<Copy SourceFiles="$(SolutionDir)TexToolWrap\PVRTexLib\Windows_x86_64\PVRTexLib.dll" DestinationFolder="$(TargetDir)" />
 		<Copy SourceFiles="$(SolutionDir)TexToolWrap\ispc\win64\ispc_texcomp.dll" DestinationFolder="$(TargetDir)" />

--- a/JustDanceEditor.Converter/UbiArt/Tapes/Clips/ClipConverter.cs
+++ b/JustDanceEditor.Converter/UbiArt/Tapes/Clips/ClipConverter.cs
@@ -1,0 +1,44 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Formats.Asn1;
+using System.Linq;
+using System.Numerics;
+using System.Text;
+using System.Text.Json.Serialization;
+using System.Text.Json;
+
+namespace JustDanceEditor.Converter.UbiArt.Tapes.Clips;
+
+public class ClipConverter : JsonConverter<IClip>
+{
+    public override IClip Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+    {
+        using JsonDocument doc = JsonDocument.ParseValue(ref reader);
+        JsonElement root = doc.RootElement;
+
+        if (!root.TryGetProperty("__class", out JsonElement classNameElement))
+        {
+            throw new JsonException("Missing __class property.");
+        }
+
+        string className = classNameElement.GetString()!;
+
+        return className switch
+        {
+            "GoldEffectClip" => JsonSerializer.Deserialize<GoldEffectClip>(root.GetRawText(), options)!,
+            "HideUserInterfaceClip" => JsonSerializer.Deserialize<HideUserInterfaceClip>(root.GetRawText(), options)!,
+            "KaraokeClip" => JsonSerializer.Deserialize<KaraokeClip>(root.GetRawText(), options)!,
+            "MotionClip" => JsonSerializer.Deserialize<MotionClip>(root.GetRawText(), options)!,
+            "PictogramClip" => JsonSerializer.Deserialize<PictogramClip>(root.GetRawText(), options)!,
+            "SoundSetClip" => JsonSerializer.Deserialize<SoundSetClip>(root.GetRawText(), options)!,
+            "VibrationClip" => JsonSerializer.Deserialize<VibrationClip>(root.GetRawText(), options)!,
+
+            _ => throw new JsonException($"Unknown clip type: {className}"),
+        };
+    }
+
+    public override void Write(Utf8JsonWriter writer, IClip value, JsonSerializerOptions? options = null)
+    {
+        JsonSerializer.Serialize(writer, value, value.GetType(), options);
+    }
+}

--- a/JustDanceEditor.Converter/UbiArt/Tapes/Clips/GoldEffectClip.cs
+++ b/JustDanceEditor.Converter/UbiArt/Tapes/Clips/GoldEffectClip.cs
@@ -1,0 +1,12 @@
+﻿namespace JustDanceEditor.Converter.UbiArt.Tapes.Clips;
+
+public class GoldEffectClip : IClip
+{
+    public string __class { get; set; } = "GoldEffectClip";
+    public int EffectType { get; set; }
+    public long Id { get; set; }
+    public long TrackId { get; set; }
+    public int IsActive { get; set; }
+    public int StartTime { get; set; }
+    public int Duration { get; set; }
+}

--- a/JustDanceEditor.Converter/UbiArt/Tapes/Clips/HideUserInterfaceClip.cs
+++ b/JustDanceEditor.Converter/UbiArt/Tapes/Clips/HideUserInterfaceClip.cs
@@ -1,0 +1,13 @@
+﻿namespace JustDanceEditor.Converter.UbiArt.Tapes.Clips;
+
+public class HideUserInterfaceClip : IClip
+{
+    public string __class { get; set; } = "HideUserInterfaceClip";
+    public long Id { get; set; }
+    public long TrackId { get; set; }
+    public int IsActive { get; set; }
+    public int StartTime { get; set; }
+    public int Duration { get; set; }
+    public int EventType { get; set; }
+    public string CustomParam { get; set; } = "";
+}

--- a/JustDanceEditor.Converter/UbiArt/Tapes/Clips/IClip.cs
+++ b/JustDanceEditor.Converter/UbiArt/Tapes/Clips/IClip.cs
@@ -1,10 +1,15 @@
-﻿namespace JustDanceEditor.Converter.UbiArt.Tapes.Clips;
+﻿using JustDanceEditor.Converter.Helpers;
+
+using System.Text.Json.Serialization;
+
+namespace JustDanceEditor.Converter.UbiArt.Tapes.Clips;
 
 public interface IClip
 {
     public string __class { get; set; }
     public long Id { get; set; }
     public long TrackId { get; set; }
+    [JsonConverter(typeof(IntBoolConverter))]
     public int IsActive { get; set; }
     public int StartTime { get; set; }
     public int Duration { get; set; }

--- a/JustDanceEditor.Converter/UbiArt/Tapes/Clips/IClip.cs
+++ b/JustDanceEditor.Converter/UbiArt/Tapes/Clips/IClip.cs
@@ -1,0 +1,11 @@
+﻿namespace JustDanceEditor.Converter.UbiArt.Tapes.Clips;
+
+public interface IClip
+{
+    public string __class { get; set; }
+    public long Id { get; set; }
+    public long TrackId { get; set; }
+    public int IsActive { get; set; }
+    public int StartTime { get; set; }
+    public int Duration { get; set; }
+}

--- a/JustDanceEditor.Converter/UbiArt/Tapes/Clips/KaraokeClip.cs
+++ b/JustDanceEditor.Converter/UbiArt/Tapes/Clips/KaraokeClip.cs
@@ -1,0 +1,18 @@
+﻿namespace JustDanceEditor.Converter.UbiArt.Tapes.Clips;
+
+public class KaraokeClip : IClip
+{
+    public string __class { get; set; } = "";
+    public long Id { get; set; }
+    public long TrackId { get; set; }
+    public int IsActive { get; set; }
+    public int StartTime { get; set; }
+    public int Duration { get; set; }
+    public float Pitch { get; set; }
+    public string Lyrics { get; set; } = "";
+    public int IsEndOfLine { get; set; }
+    public int ContentType { get; set; }
+    public int StartTimeTolerance { get; set; }
+    public int EndTimeTolerance { get; set; }
+    public float SemitoneTolerance { get; set; }
+}

--- a/JustDanceEditor.Converter/UbiArt/Tapes/Clips/MotionClip.cs
+++ b/JustDanceEditor.Converter/UbiArt/Tapes/Clips/MotionClip.cs
@@ -12,5 +12,4 @@ public class MotionClip : IClip
     public int GoldMove { get; set; }
     public int CoachId { get; set; }
     public int MoveType { get; set; }
-    public int EffectType { get; set; }
 }

--- a/JustDanceEditor.Converter/UbiArt/Tapes/Clips/MotionClip.cs
+++ b/JustDanceEditor.Converter/UbiArt/Tapes/Clips/MotionClip.cs
@@ -1,0 +1,16 @@
+﻿namespace JustDanceEditor.Converter.UbiArt.Tapes.Clips;
+
+public class MotionClip : IClip
+{
+    public string __class { get; set; } = "MotionClip";
+    public long Id { get; set; }
+    public long TrackId { get; set; }
+    public int IsActive { get; set; }
+    public int StartTime { get; set; }
+    public int Duration { get; set; }
+    public string ClassifierPath { get; set; } = "";
+    public int GoldMove { get; set; }
+    public int CoachId { get; set; }
+    public int MoveType { get; set; }
+    public int EffectType { get; set; }
+}

--- a/JustDanceEditor.Converter/UbiArt/Tapes/Clips/PictogramClip.cs
+++ b/JustDanceEditor.Converter/UbiArt/Tapes/Clips/PictogramClip.cs
@@ -1,0 +1,13 @@
+﻿namespace JustDanceEditor.Converter.UbiArt.Tapes.Clips;
+
+public class PictogramClip : IClip
+{
+    public string __class { get; set; } = "PictogramClip";
+    public long Id { get; set; }
+    public long TrackId { get; set; }
+    public int IsActive { get; set; }
+    public int StartTime { get; set; }
+    public int Duration { get; set; }
+    public string PictoPath { get; set; } = "";
+    public long CoachCount { get; set; }
+}

--- a/JustDanceEditor.Converter/UbiArt/Tapes/Clips/SoundSetClip.cs
+++ b/JustDanceEditor.Converter/UbiArt/Tapes/Clips/SoundSetClip.cs
@@ -1,0 +1,16 @@
+﻿namespace JustDanceEditor.Converter.UbiArt.Tapes.Clips;
+
+public class SoundSetClip : IClip
+{
+    public string __class { get; set; } = "SoundSetClip";
+    public long Id { get; set; }
+    public long TrackId { get; set; }
+    public int IsActive { get; set; }
+    public int StartTime { get; set; }
+    public int Duration { get; set; }
+    public string SoundSetPath { get; set; } = "";
+    public int SoundChannel { get; set; }
+    public int StartOffset { get; set; }
+    public int StopsOnEnd { get; set; }
+    public int AccountedForDuration { get; set; }
+}

--- a/JustDanceEditor.Converter/UbiArt/Tapes/Clips/VibrationClip.cs
+++ b/JustDanceEditor.Converter/UbiArt/Tapes/Clips/VibrationClip.cs
@@ -1,0 +1,18 @@
+﻿namespace JustDanceEditor.Converter.UbiArt.Tapes.Clips;
+
+public class VibrationClip : IClip
+{
+    public string __class { get; set; } = "VibrationClip";
+    public long Id { get; set; }
+    public long TrackId { get; set; }
+    public int IsActive { get; set; }
+    public int StartTime { get; set; }
+    public int Duration { get; set; }
+    public string VibrationFilePath { get; set; } = "";
+    public int Loop { get; set; }
+    public int DeviceSide { get; set; }
+    public int PlayerId { get; set; }
+    public int Context { get; set; }
+    public int StartTimeOffset { get; set; }
+    public float Modulation { get; set; }
+}

--- a/JustDanceEditor.Converter/UbiArt/Tapes/DanceTape.cs
+++ b/JustDanceEditor.Converter/UbiArt/Tapes/DanceTape.cs
@@ -1,29 +1,14 @@
-﻿namespace JustDanceEditor.Converter.UbiArt.Tapes;
+﻿using JustDanceEditor.Converter.UbiArt.Tapes.Clips;
+
+namespace JustDanceEditor.Converter.UbiArt.Tapes;
 
 public class DanceTape
 {
     public string __class { get; set; } = "";
-    public MotionClip[] Clips { get; set; } = [];
+    public IClip[] Clips { get; set; } = [];
     public int TapeClock { get; set; }
     public int TapeBarCount { get; set; }
     public int FreeResourcesAfterPlay { get; set; }
     public string MapName { get; set; } = "";
     public string SoundwichEvent { get; set; } = "";
-}
-
-public class MotionClip
-{
-    public string __class { get; set; } = "";
-    public long Id { get; set; }
-    public long TrackId { get; set; }
-    public int IsActive { get; set; }
-    public int StartTime { get; set; }
-    public int Duration { get; set; }
-    public string ClassifierPath { get; set; } = "";
-    public int GoldMove { get; set; }
-    public int CoachId { get; set; }
-    public int MoveType { get; set; }
-    public int EffectType { get; set; }
-    public string PictoPath { get; set; } = "";
-    public long CoachCount { get; set; }
 }

--- a/JustDanceEditor.Converter/UbiArt/Tapes/KaraokeTape.cs
+++ b/JustDanceEditor.Converter/UbiArt/Tapes/KaraokeTape.cs
@@ -1,30 +1,14 @@
-﻿namespace JustDanceEditor.Converter.UbiArt.Tapes;
+﻿using JustDanceEditor.Converter.UbiArt.Tapes.Clips;
+
+namespace JustDanceEditor.Converter.UbiArt.Tapes;
 
 public class KaraokeTape
 {
     public string __class { get; set; } = "";
-    public KaraokeClip[] Clips { get; set; } = [];
+    public IClip[] Clips { get; set; } = [];
     public int TapeClock { get; set; }
     public int TapeBarCount { get; set; }
     public int FreeResourcesAfterPlay { get; set; }
     public string MapName { get; set; } = "";
     public string SoundwichEvent { get; set; } = "";
 }
-
-public class KaraokeClip
-{
-    public string __class { get; set; } = "";
-    public long Id { get; set; }
-    public long TrackId { get; set; }
-    public int IsActive { get; set; }
-    public int StartTime { get; set; }
-    public int Duration { get; set; }
-    public float Pitch { get; set; }
-    public string Lyrics { get; set; } = "";
-    public int IsEndOfLine { get; set; }
-    public int ContentType { get; set; }
-    public int StartTimeTolerance { get; set; }
-    public int EndTimeTolerance { get; set; }
-    public float SemitoneTolerance { get; set; }
-}
-

--- a/JustDanceEditor.Converter/UbiArt/Tapes/MainSequence.cs
+++ b/JustDanceEditor.Converter/UbiArt/Tapes/MainSequence.cs
@@ -1,35 +1,14 @@
-﻿namespace JustDanceEditor.Converter.UbiArt.Tapes;
+﻿using JustDanceEditor.Converter.UbiArt.Tapes.Clips;
+
+namespace JustDanceEditor.Converter.UbiArt.Tapes;
 
 public class MainSequence
 {
     public string __class { get; set; } = "";
-    public MainSequenceClip[] Clips { get; set; } = [];
+    public IClip[] Clips { get; set; } = [];
     public int TapeClock { get; set; }
     public int TapeBarCount { get; set; }
     public int FreeResourcesAfterPlay { get; set; }
     public string MapName { get; set; } = "";
     public string SoundwichEvent { get; set; } = "";
-}
-
-public class MainSequenceClip
-{
-    public string __class { get; set; } = "";
-    public long Id { get; set; }
-    public long TrackId { get; set; }
-    public int IsActive { get; set; }
-    public int StartTime { get; set; }
-    public int Duration { get; set; }
-    public int EventType { get; set; }
-    public string SoundSetPath { get; set; } = "";
-    public int SoundChannel { get; set; }
-    public int StartOffset { get; set; }
-    public int StopsOnEnd { get; set; }
-    public int AccountedForDuration { get; set; }
-    public string VibrationFilePath { get; set; } = "";
-    public int Loop { get; set; }
-    public int DeviceSide { get; set; }
-    public int PlayerId { get; set; }
-    public int Context { get; set; }
-    public int StartTimeOffset { get; set; }
-    public float Modulation { get; set; }
 }


### PR DESCRIPTION
#### PR Classification
API change to introduce a more generic clip handling system and improve JSON serialization.

#### PR Summary
Refactored clip handling to use a generic `IClip` interface and added new JSON converters.
- Updated `DanceTape`, `KaraokeTape`, and `MainSequence` classes to use `IClip` instead of specific clip types.
- Modified `MapPackageBundleGenerator` to handle `IClip` and specific clip types in switch cases and loops.
- Introduced `ClipConverter` and `IntBoolConverter` classes for JSON serialization/deserialization.
- Created new clip type classes implementing `IClip`.
- Enhanced `ConvertUbiArtToUnity` to use new converters for song data deserialization.
