### PR TITLE
Switch to Nerdbank.GitVersioning for version management

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,0 +1,9 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="Current" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <PackageReference Include="Nerdbank.GitVersioning" Condition="!Exists('packages.config')">
+      <PrivateAssets>all</PrivateAssets>
+      <Version>3.6.143</Version>
+    </PackageReference>
+  </ItemGroup>
+</Project>

--- a/JustDanceEditor.UI/Program.cs
+++ b/JustDanceEditor.UI/Program.cs
@@ -15,8 +15,10 @@ internal class Program
 
         Console.WriteLine("Just Dance Editor");
         Console.WriteLine("Made by: MrKev312");
-        
-        string message = $"Version: {Assembly.GetExecutingAssembly().GetName().Version}-preview3";
+
+        // Get version from nerdbank.gitversioning
+        string message = $"Version: {Assembly.GetExecutingAssembly().GetCustomAttribute<AssemblyInformationalVersionAttribute>()!.InformationalVersion}";
+
         Logger.Log(message, LogLevel.Debug);
         Console.WriteLine(message);
         message = $"Current Directory: {Environment.CurrentDirectory}";

--- a/version.json
+++ b/version.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
+  "version": "2.0-preview",
+  "publicReleaseRefSpec": [
+    "^refs/heads/master$",
+    "^refs/heads/v\\d+(?:\\.\\d+)?$"
+  ],
+  "release": {
+    "firstUnstableTag": "preview"
+  },
+  "cloudBuild": {
+    "buildNumber": {
+      "enabled": true
+    }
+  }
+}


### PR DESCRIPTION
#### PR Classification
New feature: Implemented versioning using `Nerdbank.GitVersioning`.

#### PR Summary
Updated the project to use `Nerdbank.GitVersioning` for version management.
- `Directory.Build.props`: Added conditional package reference for `Nerdbank.GitVersioning` version `3.6.143`.
- `Program.cs`: Changed version retrieval to use `AssemblyInformationalVersionAttribute` from `Nerdbank.GitVersioning`.
- Added `version.json` to configure `Nerdbank.GitVersioning` with version `2.0-preview` and other settings.
