### PR TITLE
Refactor to use a new FileSystem

### DIFF
--- a/JustDanceEditor.Converter/ConversionRequest.cs
+++ b/JustDanceEditor.Converter/ConversionRequest.cs
@@ -1,7 +1,11 @@
 ﻿namespace JustDanceEditor.Converter;
 
-public class ConversionRequest
+public struct ConversionRequest
 {
+    public ConversionRequest()
+    {
+    }
+
     // Folder where the input files are located
     public required string InputPath { get; set; }
     // Folder where the output will be saved
@@ -13,7 +17,7 @@ public class ConversionRequest
     // Name of the song (optional)
     public string? SongName { get; set; } = null;
     // GUID of the song
-    public string SongID { get; set; } = Guid.NewGuid().ToString();
+    public string SongGUID { get; set; } = Guid.NewGuid().ToString();
     // Cache number
     public uint? CacheNumber { get; set; } = null;
     public uint? JDVersion { get; set; } = null;

--- a/JustDanceEditor.Converter/Converters/Audio/AudioConverter.cs
+++ b/JustDanceEditor.Converter/Converters/Audio/AudioConverter.cs
@@ -167,8 +167,7 @@ public static class AudioConverter
     static CookedFile GetMainSongPath(ConvertUbiArtToUnity convert)
     {
         // First we check the media folder
-        string mediaFolder = convert.FileSystem.InputFolders.MediaFolder;
-        if (Directory.Exists(mediaFolder))
+        if (convert.FileSystem.GetFolderPath(convert.FileSystem.InputFolders.MediaFolder, out string? mediaFolder))
         {
             string[] oggFiles = Directory.GetFiles(mediaFolder, "*.ogg", SearchOption.AllDirectories);
             if (oggFiles.Length > 0)

--- a/JustDanceEditor.Converter/Converters/Audio/AudioConverter.cs
+++ b/JustDanceEditor.Converter/Converters/Audio/AudioConverter.cs
@@ -32,7 +32,7 @@ public static class AudioConverter
     {
         Logger.Log("Converting audio files...");
         Stopwatch stopwatch = Stopwatch.StartNew();
-        SoundSetClip[] audioClips = GetAudioClips(convert.SongData.Clips);
+        SoundSetClip[] audioClips = GetAudioClips([.. convert.SongData.Clips]);
 
         string mainSongPath = GetMainSongPath(convert);
         string newMainSongPath = ConvertMainSong(convert, mainSongPath);
@@ -203,7 +203,8 @@ public static class AudioConverter
         //if (audios.Count > 0)
         //    return audios.First();
 
-        // TODO: read the isc and use that path
+        // TODO: Get the path from the mtrack
+        //convert.SongData.MusicTrack.COMPONENTS[0].trackData.path;
 
         throw new Exception("Main song not found");
     }

--- a/JustDanceEditor.Converter/Converters/Bundles/CoachesLargeBundleGenerator.cs
+++ b/JustDanceEditor.Converter/Converters/Bundles/CoachesLargeBundleGenerator.cs
@@ -34,7 +34,7 @@ public static class CoachesLargeBundleGenerator
     {
         // Get the coaches folder
         // /template/cachex/CoachesLarge/*
-        string coacheLargePackagePath = Directory.GetFiles(Path.Combine(convert.TemplateFolder, "CoachesLarge"))[0];
+        string coacheLargePackagePath = convert.FileSystem.TemplateFiles.CoachesLarge;
 
         Logger.Log("Converting CoachesLarge...");
         // Open the coaches package using AssetTools.NET
@@ -142,7 +142,7 @@ public static class CoachesLargeBundleGenerator
             coachTextureBaseField["m_Name"].AsString = $"{convert.SongData.Name}_Coach_{i}";
             coachSpriteBaseField["m_Name"].AsString = $"{convert.SongData.Name}_Coach_{i}";
 
-            string path = Path.Combine(convert.TempMenuArtFolder, $"{convert.SongData.Name}_Coach_{i}.tga.png");
+            string path = Path.Combine(convert.FileSystem.TempFolders.MenuArtFolder, $"{convert.SongData.Name}_Coach_{i}.tga.png");
 
             // Load the image
             Image<Rgba32> image = Image.Load<Rgba32>(path);
@@ -250,7 +250,7 @@ public static class CoachesLargeBundleGenerator
         bun.BlockAndDirInfo.DirectoryInfos[0].SetNewData(afile);
 
         // Add .mod to the end of the file
-        string outputPackagePath = Path.Combine(convert.OutputXFolder, "CoachesLarge");
+        string outputPackagePath = convert.FileSystem.OutputFolders.CoachesLargeFolder;
         bun.SaveAndCompress(outputPackagePath);
     }
 }

--- a/JustDanceEditor.Converter/Converters/Bundles/CoachesLargeBundleGenerator.cs
+++ b/JustDanceEditor.Converter/Converters/Bundles/CoachesLargeBundleGenerator.cs
@@ -142,7 +142,7 @@ public static class CoachesLargeBundleGenerator
             coachTextureBaseField["m_Name"].AsString = $"{convert.SongData.Name}_Coach_{i}";
             coachSpriteBaseField["m_Name"].AsString = $"{convert.SongData.Name}_Coach_{i}";
 
-            string path = Path.Combine(convert.FileSystem.TempFolders.MenuArtFolder, $"{convert.SongData.Name}_Coach_{i}.tga.png");
+            string path = Path.Combine(convert.FileSystem.TempFolders.MenuArtFolder, $"{convert.SongData.Name}_Coach_{i}.png");
 
             // Load the image
             Image<Rgba32> image = Image.Load<Rgba32>(path);

--- a/JustDanceEditor.Converter/Converters/Bundles/CoachesSmallBundleGenerator.cs
+++ b/JustDanceEditor.Converter/Converters/Bundles/CoachesSmallBundleGenerator.cs
@@ -34,7 +34,7 @@ public static class CoachesSmallBundleGenerator
     {
         // Get the coaches folder
         // /template/cachex/CoachesSmall/*
-        string coacheLargePackagePath = Directory.GetFiles(Path.Combine(convert.TemplateFolder, "CoachesSmall"))[0];
+        string coacheLargePackagePath = convert.FileSystem.TemplateFiles.CoachesLarge;
 
         Logger.Log("Converting CoachesSmall...");
         // Open the coaches package using AssetTools.NET
@@ -124,7 +124,7 @@ public static class CoachesSmallBundleGenerator
             coachTextureBaseField["m_Name"].AsString = $"{convert.SongData.Name}_Coach_{i}_Phone";
             coachSpriteBaseField["m_Name"].AsString = $"{convert.SongData.Name}_Coach_{i}_Phone";
 
-            string path = Path.Combine(convert.TempMenuArtFolder, $"{convert.SongData.Name}_Coach_{i}.tga.png");
+            string path = Path.Combine(convert.FileSystem.TempFolders.MenuArtFolder, $"{convert.SongData.Name}_Coach_{i}.tga.png");
 
             // Load the image and resize it to 256x256
             Image<Rgba32> image = Image.Load<Rgba32>(path);
@@ -205,7 +205,7 @@ public static class CoachesSmallBundleGenerator
         bun.BlockAndDirInfo.DirectoryInfos[0].SetNewData(afile);
 
         // Add .mod to the end of the file
-        string outputPackagePath = Path.Combine(convert.OutputXFolder, "CoachesSmall");
+        string outputPackagePath = convert.FileSystem.OutputFolders.CoachesSmallFolder;
         bun.SaveAndCompress(outputPackagePath);
     }
 }

--- a/JustDanceEditor.Converter/Converters/Bundles/CoachesSmallBundleGenerator.cs
+++ b/JustDanceEditor.Converter/Converters/Bundles/CoachesSmallBundleGenerator.cs
@@ -34,7 +34,7 @@ public static class CoachesSmallBundleGenerator
     {
         // Get the coaches folder
         // /template/cachex/CoachesSmall/*
-        string coacheLargePackagePath = convert.FileSystem.TemplateFiles.CoachesLarge;
+        string coacheLargePackagePath = convert.FileSystem.TemplateFiles.CoachesSmall;
 
         Logger.Log("Converting CoachesSmall...");
         // Open the coaches package using AssetTools.NET
@@ -124,7 +124,7 @@ public static class CoachesSmallBundleGenerator
             coachTextureBaseField["m_Name"].AsString = $"{convert.SongData.Name}_Coach_{i}_Phone";
             coachSpriteBaseField["m_Name"].AsString = $"{convert.SongData.Name}_Coach_{i}_Phone";
 
-            string path = Path.Combine(convert.FileSystem.TempFolders.MenuArtFolder, $"{convert.SongData.Name}_Coach_{i}.tga.png");
+            string path = Path.Combine(convert.FileSystem.TempFolders.MenuArtFolder, $"{convert.SongData.Name}_Coach_{i}.png");
 
             // Load the image and resize it to 256x256
             Image<Rgba32> image = Image.Load<Rgba32>(path);

--- a/JustDanceEditor.Converter/Converters/Bundles/CoverBundleGenerator.cs
+++ b/JustDanceEditor.Converter/Converters/Bundles/CoverBundleGenerator.cs
@@ -32,7 +32,7 @@ public static class CoverBundleGenerator
 
     static void GenerateCoverInternal(ConvertUbiArtToUnity convert)
     {
-        string coverPackagePath = Directory.GetFiles(Path.Combine(convert.TemplateFolder, "Cover"))[0];
+        string coverPackagePath = convert.FileSystem.TemplateFiles.Cover;
 
         Logger.Log("Converting Cover...");
 
@@ -67,14 +67,14 @@ public static class CoverBundleGenerator
         coverImage ??= CoverArtGenerator.GenerateOwnCover(convert);
 
         // Save the image in the temp folder
-        coverImage.Save(Path.Combine(convert.TempMenuArtFolder, $"Cover_{convert.SongData.Name}.png"));
+        coverImage.Save(Path.Combine(convert.FileSystem.TempFolders.MenuArtFolder, $"Cover_{convert.SongData.Name}.png"));
 
         // Now we can encode the image
         {
             byte[] encImageBytes;
             TextureFormat fmt = TextureFormat.DXT1Crunched;
             int mips = 1;
-            string path = Path.Combine(convert.TempMenuArtFolder, $"{convert.SongData.Name}_map_bkg.tga.png");
+            string path = Path.Combine(convert.FileSystem.TempFolders.MenuArtFolder, $"{convert.SongData.Name}_map_bkg.tga.png");
 
             encImageBytes = TextureImportExport.Import(coverImage!, fmt, out int width, out int height, ref mips) ?? throw new Exception("Failed to encode image!");
 
@@ -106,7 +106,7 @@ public static class CoverBundleGenerator
         bun.BlockAndDirInfo.DirectoryInfos[0].SetNewData(afile);
 
         // Write the file
-        string outputPackagePath = Path.Combine(convert.Output0Folder, "Cover");
+        string outputPackagePath = convert.FileSystem.OutputFolders.CoverFolder;
         bun.SaveAndCompress(outputPackagePath);
     }
 }

--- a/JustDanceEditor.Converter/Converters/Bundles/MapPackageBundleGenerator.cs
+++ b/JustDanceEditor.Converter/Converters/Bundles/MapPackageBundleGenerator.cs
@@ -256,7 +256,11 @@ public static class MapPackageBundleGenerator
         movesArray.Children.Clear();
 
         // Add the new dance moves
-        string[] moveFiles = Directory.GetFiles(convert.FileSystem.InputFolders.MovesFolder);
+        string[] moveFiles = [];
+
+        if (convert.FileSystem.GetFolderPath(convert.FileSystem.InputFolders.MovesFolder, out string? movesFolder))
+            moveFiles = Directory.GetFiles(movesFolder);
+
         foreach (string item in moveFiles)
         {
             // Get the file name and content, must read as bytes

--- a/JustDanceEditor.Converter/Converters/Bundles/MapPackageBundleGenerator.cs
+++ b/JustDanceEditor.Converter/Converters/Bundles/MapPackageBundleGenerator.cs
@@ -35,7 +35,7 @@ public static class MapPackageBundleGenerator
     {
         // Get the mapPackage path
         // /template/cachex/MapPackage/*
-        string mapPackagePath = Directory.GetFiles(Path.Combine(convert.TemplateFolder, "MapPackage"))[0];
+        string mapPackagePath = convert.FileSystem.TemplateFiles.MapPackage;
 
         // Convert the pictos in /cache/itf_cooked/nx/world/maps/{mapName}/timeline/pictos
         Task<(Dictionary<string, (int index, (int Width, int Height))>, List<Image<Rgba32>>)> pictoTask =
@@ -256,7 +256,7 @@ public static class MapPackageBundleGenerator
         movesArray.Children.Clear();
 
         // Add the new dance moves
-        string[] moveFiles = Directory.GetFiles(convert.MovesFolder);
+        string[] moveFiles = Directory.GetFiles(convert.FileSystem.InputFolders.MovesFolder);
         foreach (string item in moveFiles)
         {
             // Get the file name and content, must read as bytes
@@ -298,7 +298,7 @@ public static class MapPackageBundleGenerator
         (Dictionary<string, (int index, (int width, int height) size)> imageDict, List<Image<Rgba32>> atlasPics) = pictoTask.Result;
 
         // Add the new pictos
-        string[] FileDirs = Directory.GetFiles(Path.Combine(convert.TempPictoFolder, "Atlas"));
+        string[] FileDirs = Directory.GetFiles(Path.Combine(convert.FileSystem.TempFolders.PictoFolder, "Atlas"));
         byte[][] endImageBytes = new byte[FileDirs.Length][];
 
         Parallel.For(0, FileDirs.Length, i =>
@@ -383,7 +383,7 @@ public static class MapPackageBundleGenerator
         }
 
         // Then add all the pictos to the bundle
-        FileDirs = Directory.GetFiles(convert.TempPictoFolder);
+        FileDirs = Directory.GetFiles(convert.FileSystem.TempFolders.PictoFolder);
 
         for (int i = 0; i < FileDirs.Length; i++)
         {
@@ -660,7 +660,7 @@ public static class MapPackageBundleGenerator
         bun.BlockAndDirInfo.DirectoryInfos[0].SetNewData(afile);
 
         // Add .mod to the end of the file
-        string outputPackagePath = Path.Combine(convert.OutputXFolder, "MapPackage");
+        string outputPackagePath = convert.FileSystem.OutputFolders.MapPackageFolder;
         bun.SaveAndCompress(outputPackagePath);
     }
 }

--- a/JustDanceEditor.Converter/Converters/Bundles/SongTitleLogoBundleGenerator.cs
+++ b/JustDanceEditor.Converter/Converters/Bundles/SongTitleLogoBundleGenerator.cs
@@ -37,7 +37,7 @@ public static class SongTitleBundleGenerator
         //string logoPath = Path.Combine(convert.InputMenuArtFolder, "songTitleLogo.png");
         FileSystem fs = convert.FileSystem;
 
-        if (fs.GetFilePath(Path.Combine(fs.InputFolders.MenuArtFolder), out string? logoPath) || logoPath == null)
+        if (fs.GetFilePath(Path.Combine(fs.InputFolders.MenuArtFolder), out CookedFile? logoPath) || logoPath == null)
         {
             //Console.WriteLine("No songTitleLogo.png found, skipping...");
             Logger.Log("No songTitleLogo.png found, skipping...", LogLevel.Important);

--- a/JustDanceEditor.Converter/Converters/Bundles/SongTitleLogoBundleGenerator.cs
+++ b/JustDanceEditor.Converter/Converters/Bundles/SongTitleLogoBundleGenerator.cs
@@ -10,6 +10,7 @@ using SixLabors.ImageSharp;
 using SixLabors.ImageSharp.PixelFormats;
 using SixLabors.ImageSharp.Processing;
 using TextureConverter;
+using JustDanceEditor.Converter.Files;
 
 namespace JustDanceEditor.Converter.Converters.Bundles;
 
@@ -33,22 +34,17 @@ public static class SongTitleBundleGenerator
     static void GenerateSongTitleLogoInternal(ConvertUbiArtToUnity convert)
     {
         // Does the following exist?
-        string logoPath = Path.Combine(convert.InputMenuArtFolder, "songTitleLogo.png");
-        if (!File.Exists(logoPath))
+        //string logoPath = Path.Combine(convert.InputMenuArtFolder, "songTitleLogo.png");
+        FileSystem fs = convert.FileSystem;
+
+        if (fs.GetFilePath(Path.Combine(fs.InputFolders.MenuArtFolder), out string? logoPath) || logoPath == null)
         {
             //Console.WriteLine("No songTitleLogo.png found, skipping...");
-            Logger.Log("No songTitleLogo.png found, skipping...", LogLevel.Warning);
+            Logger.Log("No songTitleLogo.png found, skipping...", LogLevel.Important);
             return;
         }
 
-        string[] songTitleLogoPackagePaths = Directory.GetFiles(Path.Combine(convert.TemplateFolder, "songTitleLogo"));
-        if (songTitleLogoPackagePaths.Length == 0)
-        {
-            Logger.Log("No songTitleLogo bundle found despite songTitleLogo.png existing, skipping...", LogLevel.Warning);
-            return;
-        }
-
-        string songTitleLogoPackagePath = songTitleLogoPackagePaths[0];
+        string songTitleLogoPackagePath = fs.TemplateFiles.SongTitleLogo;
 
         Logger.Log("Converting SongTitleLogo...");
 
@@ -90,10 +86,7 @@ public static class SongTitleBundleGenerator
         {
             byte[] encImageBytes;
             TextureFormat fmt = TextureFormat.DXT5Crunched;
-            byte[] platformBlob = [];
-            uint platform = afile.Metadata.TargetPlatform;
             int mips = 1;
-            string path = Path.Combine(convert.InputMenuArtFolder, "songTitleLogo.png");
 
             encImageBytes = TextureImportExport.Import(image, fmt, out int width, out int height, ref mips) ?? throw new Exception("Failed to encode image!");
 
@@ -125,7 +118,7 @@ public static class SongTitleBundleGenerator
         bun.BlockAndDirInfo.DirectoryInfos[0].SetNewData(afile);
 
         // Write the file
-        string outputPackagePath = Path.Combine(convert.Output0Folder, "songTitleLogo");
+        string outputPackagePath = fs.OutputFolders.SongTitleLogoFolder;
         bun.SaveAndCompress(outputPackagePath);
     }
 }

--- a/JustDanceEditor.Converter/Converters/ConvertUbiArtToUnity.cs
+++ b/JustDanceEditor.Converter/Converters/ConvertUbiArtToUnity.cs
@@ -1,6 +1,8 @@
 ﻿using System.Diagnostics;
 using System.Text.Json;
 
+using JustDanceEditor.Converter.Files;
+
 using JustDanceEditor.Converter.Converters.Audio;
 using JustDanceEditor.Converter.Converters.Bundles;
 using JustDanceEditor.Converter.Converters.Cache;
@@ -15,43 +17,17 @@ using JustDanceEditor.Converter.Helpers;
 
 using Xabe.FFmpeg.Downloader;
 using JustDanceEditor.Logging;
-using System.Globalization;
+
 
 namespace JustDanceEditor.Converter.Converters;
 
 public class ConvertUbiArtToUnity(ConversionRequest conversionRequest)
 {
     public JDUbiArtSong SongData { get; private set; } = new();
-    public readonly ConversionRequest ConversionRequest = conversionRequest;
+    public ConversionRequest ConversionRequest = conversionRequest;
+    public FileSystem FileSystem { get; private set; } = new(conversionRequest);
 
-    /// Folders
-    // Main folders
-    public string InputFolder => ConversionRequest.InputPath;
-    public string InputMenuArtFolder => Path.Combine(WorldFolder, "menuart");
-    public string InputMediaFolder => Path.Combine(WorldFolder, "media");
-    public string OutputFolder => Path.Combine(ConversionRequest.OutputPath, SongData.Name);
-    public string Output0Folder => Path.Combine(OutputFolder, $"SD_Cache.0000", "MapBaseCache", SongID);
-    public string OutputXFolder => Path.Combine(OutputFolder, $"SD_Cache.{CacheNumber:X4}", SongID);
-    public string TemplateFolder => ConversionRequest.TemplatePath;
-    public string SongID => ConversionRequest.SongID;
-    public uint CacheNumber => ConversionRequest.CacheNumber ?? 123;
-    // Temporary folders
-    public string TempMapFolder => Path.Combine(Path.GetTempPath(), "JustDanceEditor", SongData.Name);
-    public string TempPictoFolder => Path.Combine(TempMapFolder, "pictos");
-    public string TempPictoAtlasFolder => Path.Combine(TempPictoFolder, "Atlas");
-    public string TempMenuArtFolder => Path.Combine(TempMapFolder, "menuart");
-    public string TempAudioFolder => Path.Combine(TempMapFolder, "audio");
-    public string TempVideoFolder => Path.Combine(TempMapFolder, "video");
-    public string PlatformType { get; private set; } = "NX";
-    // Specific map folders
-    public string CacheFolder => Path.Combine(InputFolder, "cache", "itf_cooked", PlatformType, "world", "maps", SongData.Name);
-    public string WorldFolder => Path.Combine(InputFolder, "world", "maps", SongData.Name);
-    public string TimelineFolder => Path.Combine(CacheFolder, "timeline");
-    public string MovesFolder => Path.Combine(WorldFolder, "timeline", "moves", "wiiu");
-    public string PictosFolder => Path.Combine(TimelineFolder, "pictos");
-    public string MenuArtFolder => SongData.EngineVersion == JDVersion.JDUnlimited ?
-        InputMenuArtFolder :
-        Path.Combine(CacheFolder, "menuart", "textures");
+    public string SongID => ConversionRequest.SongGUID;
 
     public void Convert()
     {
@@ -68,12 +44,6 @@ public class ConvertUbiArtToUnity(ConversionRequest conversionRequest)
         // Load the song data
         LoadSongData();
 
-        // Given that we can load the song data, we can determine the cache number
-        DetermineCacheNumber();
-
-        // Create the folders
-        CreateTempFolders();
-
         // Convert the files
         ConversionTasks();
 
@@ -85,7 +55,7 @@ public class ConvertUbiArtToUnity(ConversionRequest conversionRequest)
 
 #if RELEASE
         if (canClearTemp)
-            ClearTemp();
+            FileSystem.TempFolders.Delete();
 #endif
 
         stopwatch.Stop();
@@ -94,23 +64,10 @@ public class ConvertUbiArtToUnity(ConversionRequest conversionRequest)
         return;
     }
 
-    void ClearTemp()
-    {
-        try
-        {
-            Logger.Log("Clearing temp folders", LogLevel.Debug);
-            Directory.Delete(TempMapFolder, true);
-        }
-        catch (Exception e)
-        {
-            Logger.Log($"Failed to clear temp folders: {e.Message}", LogLevel.Error);
-        }
-    }
-
     bool MergeCacheFiles()
     {
-        if (File.Exists(Path.Combine(OutputFolder, "cachingStatus.json")) &&
-            File.Exists(Path.Combine(ConversionRequest.OutputPath, "SD_Cache.0000", "MapBaseCache", "cachingStatus.json")))
+        if (File.Exists(FileSystem.OutputFolders.CachePath) &&
+            File.Exists(FileSystem.OutputFolders.CachingStatusPath))
             return CacheJsonGenerator.MergeCaches(this);
 
         return true;
@@ -165,74 +122,10 @@ public class ConvertUbiArtToUnity(ConversionRequest conversionRequest)
         Directory.CreateDirectory(ConversionRequest.OutputPath);
     }
 
-    void DetermineCacheNumber()
-    {
-        string cachingStatusPath = Path.Combine(ConversionRequest.OutputPath, "SD_Cache.0000", "MapBaseCache", "cachingStatus.json");
-
-        // If the cache number is provided, use it
-        if (ConversionRequest.CacheNumber != null)
-            return;
-        // If we're not in a real cache folder, just use 123
-        else if (!File.Exists(cachingStatusPath))
-        {
-            ConversionRequest.CacheNumber = 123;
-            Logger.Log("Setting cache number to 123", LogLevel.Important);
-            return;
-        }
-
-        // We're in a real cache folder, let's find the max cache number
-        // Get all the directories in the output path formatted as SD_Cache.xxxx
-        string[] directories = Directory.GetDirectories(ConversionRequest.OutputPath);
-
-        uint maxCacheNumber = 1;
-
-        foreach (string directory in directories)
-        {
-            // If the directory is SD_Cache.0000, skip it
-            if (Path.GetFileName(directory).Equals("SD_Cache.0000", StringComparison.CurrentCultureIgnoreCase))
-                continue;
-
-            if (directory.Contains("SD_Cache.") && uint.TryParse(directory.Split('.').Last(), NumberStyles.HexNumber, CultureInfo.InvariantCulture, out uint cacheNumber))
-                maxCacheNumber = Math.Max(maxCacheNumber, cacheNumber);
-        }
-
-        // Create the new cache folder
-        Directory.CreateDirectory(Path.Combine(ConversionRequest.OutputPath, $"SD_Cache.{maxCacheNumber:X4}"));
-
-        // If the folder of the max cache number is over 2.8 GB, we'll start a new one
-        long cacheSize = new DirectoryInfo(Path.Combine(ConversionRequest.OutputPath, $"SD_Cache.{maxCacheNumber:X4}")).EnumerateFiles("*", SearchOption.AllDirectories).Sum(f => f.Length);
-
-        ConversionRequest.CacheNumber = cacheSize > 2.8f * 1024 * 1024 * 1024 
-            ? maxCacheNumber + 1 
-            : maxCacheNumber;
-
-        Logger.Log($"Setting cache number to {CacheNumber}", LogLevel.Important);
-    }
-
     void LoadSongData()
     {
         // Load in the song data
         Logger.Log("Loading song info...");
-
-        // Set the song name to bootstrap the process
-        string mapName = ConversionRequest.SongName
-            ?? Path.GetFileName(Directory.GetDirectories(Path.Combine(ConversionRequest.InputPath, "world", "maps"))[0]);
-
-        SongData = new()
-        {
-            Name = mapName
-        };
-
-        Logger.Log($"Song name: {SongData.Name}");
-
-        string path = Path.Combine(InputFolder, "cache", "itf_cooked");
-        PlatformType = Path.GetFileName(Directory.GetDirectories(path).First())!;
-
-        string message = $"Platform: {PlatformType}";
-        if (!PlatformType.Equals("nx", StringComparison.CurrentCultureIgnoreCase))
-            message += " which is not officially supported. The conversion might not work as expected.";
-
-        Logger.Log(message);
 
         JsonSerializerOptions options = new();
         options.Converters.Add(new ClipConverter());
@@ -240,80 +133,53 @@ public class ConvertUbiArtToUnity(ConversionRequest conversionRequest)
 
         List<IClip> clips = [];
 
-        Logger.Log("Loading MusicTrack");
-        SongData.MusicTrack = JsonSerializer.Deserialize<MusicTrack>(File.ReadAllText(Path.Combine(CacheFolder, "audio", $"{SongData.Name}_musictrack.tpl.ckd")).Replace("\0", ""), options)!;
+        // Let's start with the songdesc
+        Logger.Log("Loading SongDesc");
+        string relativePath = Path.Combine("world", "maps", SongID, "songdesc.tpl.ckd");
+        string path = FileSystem.GetFilePath(relativePath);
+        SongData.SongDesc = JsonSerializer.Deserialize<SongDesc>(FileSystem.ReadWithoutNulls(path), options)!;
 
-        // Loading clips
+        // Get the map name
+        SongData.Name = SongData.SongDesc.COMPONENTS[0].MapName;
+
+        // Load the JD version
+        Logger.Log("Loading JDVersion");
+        SongData.EngineVersion = (JDVersion)SongData.SongDesc.COMPONENTS[0].JDVersion;
+        SongData.JDVersion = (JDVersion)SongData.SongDesc.COMPONENTS[0].OriginalJDVersion;
+        Logger.Log($"Loaded versions, engine: {SongData.EngineVersion}, original version: {SongData.JDVersion}");
+
+        // Load the music track
+        Logger.Log("Loading MusicTrack");
+        relativePath = Path.Combine("audio", $"{SongData.Name}_musictrack.tpl.ckd");
+        path = FileSystem.GetFilePath(relativePath);
+        SongData.MusicTrack = JsonSerializer.Deserialize<MusicTrack>(FileSystem.ReadWithoutNulls(path), options)!;
+
+        // Load the clips
         Logger.Log("Loading DanceTape");
-        ClipTape DanceTape = JsonSerializer.Deserialize<ClipTape>(File.ReadAllText(Path.Combine(TimelineFolder, $"{SongData.Name}_tml_dance.dtape.ckd")).Replace("\0", ""), options)!;
+        relativePath = Path.Combine("timeline", SongID, $"{SongData.Name}_tml_dance.dtape.ckd");
+        path = FileSystem.GetFilePath(relativePath);
+        ClipTape DanceTape = JsonSerializer.Deserialize<ClipTape>(FileSystem.ReadWithoutNulls(path), options)!;
         clips.AddRange(DanceTape.Clips);
+
         Logger.Log("Loading MainSequence");
-        ClipTape MainSequenceTape = JsonSerializer.Deserialize<ClipTape>(File.ReadAllText(Path.Combine(CacheFolder, "cinematics", $"{SongData.Name}_mainsequence.tape.ckd")).Replace("\0", ""), options)!;
+        relativePath = Path.Combine("cinematics", $"{SongData.Name}_mainsequence.tape.ckd");
+        path = FileSystem.GetFilePath(relativePath);
+        ClipTape MainSequenceTape = JsonSerializer.Deserialize<ClipTape>(FileSystem.ReadWithoutNulls(path), options)!;
         clips.AddRange(MainSequenceTape.Clips);
+
         // Some maps don't have KaraokeTape
-        if (File.Exists(Path.Combine(TimelineFolder, $"{SongData.Name}_tml_karaoke.ktape.ckd")))
+        if (FileSystem.GetFilePath(Path.Combine("timeline", $"{SongID}_tml_karaoke.ktape.ckd"), out string? karaokePath))
         {
             Logger.Log("Loading KaraokeTape");
-            ClipTape KaraokeTape = JsonSerializer.Deserialize<ClipTape>(File.ReadAllText(Path.Combine(TimelineFolder, $"{SongData.Name}_tml_karaoke.ktape.ckd")).Replace("\0", ""), options)!;
+            ClipTape KaraokeTape = JsonSerializer.Deserialize<ClipTape>(FileSystem.ReadWithoutNulls(karaokePath), options)!;
             clips.AddRange(KaraokeTape.Clips);
         }
         else
             Logger.Log("KaraokeTape not found");
+
         SongData.Clips = [.. clips];
 
-        Logger.Log("Loading SongDesc");
-        SongDesc? songDesc = null;
-        List<string> songDescLocs = [
-            Path.Combine(InputFolder, "..", "patch_nx", "cache", "itf_cooked", PlatformType, "world", "maps", SongData.Name, "songdesc.tpl.ckd"),
-            Path.Combine(InputFolder, "..", "bundle_nx", "cache", "itf_cooked", PlatformType, "world", "maps", SongData.Name, "songdesc.tpl.ckd"),
-            Path.Combine(CacheFolder, "songdesc.tpl.ckd")
-            ];
-
-        foreach (string loc in songDescLocs)
-        {
-            if (File.Exists(loc))
-            {
-                songDesc = JsonSerializer.Deserialize<SongDesc>(File.ReadAllText(loc).Replace("\0", ""), options);
-                break;
-            }
-        }
-
-        if (songDesc == null)
-            throw new FileNotFoundException("SongDesc not found");
-
-        SongData.SongDesc = songDesc;
-        SongData.Name = SongData.SongDesc.COMPONENTS[0].MapName;
-
-        // Get the JD version
-        Logger.Log("Loading JDVersion");
-        SongData.EngineVersion = !Directory.Exists(MenuArtFolder) ?
-            JDVersion.JDUnlimited :
-            (JDVersion)SongData.SongDesc.COMPONENTS[0].JDVersion;
-
-        SongData.JDVersion = (JDVersion)(ConversionRequest.JDVersion ?? SongData.SongDesc.COMPONENTS[0].OriginalJDVersion);
-
-        Logger.Log($"Loaded versions, engine: {SongData.EngineVersion}, original version: {SongData.JDVersion}");
-
         return;
-    }
-
-    void CreateTempFolders()
-    {
-        // Delete the old temp folder
-        if (Directory.Exists(TempMapFolder))
-        {
-            Logger.Log("Deleting the old temp folder", LogLevel.Debug);
-            Directory.Delete(TempMapFolder, true);
-        }
-
-        // Create the folders
-        Logger.Log("Creating temp folders", LogLevel.Debug);
-        Directory.CreateDirectory(TempMapFolder);
-        Directory.CreateDirectory(TempPictoFolder);
-        Directory.CreateDirectory(TempPictoAtlasFolder);
-        Directory.CreateDirectory(TempMenuArtFolder);
-        Directory.CreateDirectory(TempAudioFolder);
-        Directory.CreateDirectory(TempVideoFolder);
     }
 
     void ConversionTasks()

--- a/JustDanceEditor.Converter/Converters/Images/CoverArtGenerator.cs
+++ b/JustDanceEditor.Converter/Converters/Images/CoverArtGenerator.cs
@@ -15,10 +15,9 @@ public static class CoverArtGenerator
     {
         string[] paths =
         [
-            Path.Combine(convert.InputMenuArtFolder, "cover.png"),
-            Path.Combine(convert.MenuArtFolder, "cover.png"),
-            Path.Combine(convert.TempMenuArtFolder, $"{convert.SongData.Name}_cover_online.tga.png"),
-            Path.Combine(convert.TempMenuArtFolder, $"{convert.SongData.Name}_cover_generic.tga.png")
+            Path.Combine(convert.FileSystem.InputFolders.MenuArtFolder, "cover.png"),
+            Path.Combine(convert.FileSystem.InputFolders.MenuArtFolder, $"{convert.SongData.Name}_cover_online.tga.png"),
+            Path.Combine(convert.FileSystem.InputFolders.MenuArtFolder, $"{convert.SongData.Name}_cover_generic.tga.png")
         ];
 
         foreach (string path in paths)
@@ -131,9 +130,9 @@ public static class CoverArtGenerator
         Image<Rgba32>? coverImage = GetBackground(convert);
 
         // Then we load in the albumcoach
-        string albumCoachPath = Path.Combine(convert.TempMenuArtFolder, $"{convert.SongData.Name}_cover_albumcoach.tga.png");
+        string albumCoachPath = Path.Combine(convert.FileSystem.TempFolders.MenuArtFolder, $"{convert.SongData.Name}_cover_albumcoach.tga.png");
         Image<Rgba32>? albumCoach = TryLoadImage(albumCoachPath);
-        albumCoach ??= TryLoadImage(Path.Combine(convert.TempMenuArtFolder, $"{convert.SongData.Name}_Coach_1.tga.png"));
+        albumCoach ??= TryLoadImage(Path.Combine(convert.FileSystem.TempFolders.MenuArtFolder, $"{convert.SongData.Name}_Coach_1.tga.png"));
         albumCoach ??= new Image<Rgba32>(1024, 1024);
 
         albumCoach.Mutate(x => x.Resize(1024, 1024));
@@ -157,8 +156,8 @@ public static class CoverArtGenerator
     {
         // First we load in the background
         string[] paths = [
-            Path.Combine(convert.TempMenuArtFolder, $"{convert.SongData.Name}_map_bkg.tga.png"),
-            Path.Combine(convert.TempMenuArtFolder, $"{convert.SongData.Name}_banner_bkg.tga.png")
+            Path.Combine(convert.FileSystem.TempFolders.MenuArtFolder, $"{convert.SongData.Name}_map_bkg.tga.png"),
+            Path.Combine(convert.FileSystem.TempFolders.MenuArtFolder, $"{convert.SongData.Name}_banner_bkg.tga.png")
         ];
 
         Image<Rgba32>? coverImage = null;

--- a/JustDanceEditor.Converter/Converters/Images/CoverArtGenerator.cs
+++ b/JustDanceEditor.Converter/Converters/Images/CoverArtGenerator.cs
@@ -17,14 +17,14 @@ public static class CoverArtGenerator
     {
         string[] paths =
         [
-            Path.Combine(convert.FileSystem.InputFolders.MenuArtFolder, "cover.png"),
-            Path.Combine(convert.FileSystem.InputFolders.MenuArtFolder, $"{convert.SongData.Name}_cover_online.png"),
-            Path.Combine(convert.FileSystem.InputFolders.MenuArtFolder, $"{convert.SongData.Name}_cover_generic.png")
+            Path.Combine(convert.FileSystem.TempFolders.MenuArtFolder, "cover.png"),
+            Path.Combine(convert.FileSystem.TempFolders.MenuArtFolder, $"{convert.SongData.Name}_cover_online.png"),
+            Path.Combine(convert.FileSystem.TempFolders.MenuArtFolder, $"{convert.SongData.Name}_cover_generic.png")
         ];
 
-        foreach (string relativePath in paths)
+        foreach (string path in paths)
         {
-            if (!convert.FileSystem.GetFilePath(relativePath, out CookedFile? path))
+            if (!File.Exists(path))
                 continue;
 
             Image<Rgba32>? image = TryLoadImage(path);

--- a/JustDanceEditor.Converter/Converters/Images/CoverArtGenerator.cs
+++ b/JustDanceEditor.Converter/Converters/Images/CoverArtGenerator.cs
@@ -1,11 +1,13 @@
 ﻿using HtmlAgilityPack;
 
+using JustDanceEditor.Logging;
+using JustDanceEditor.Converter.Files;
+
 using SixLabors.ImageSharp;
 using SixLabors.ImageSharp.PixelFormats;
 using SixLabors.ImageSharp.Processing;
 using SixLabors.ImageSharp.Drawing.Processing;
 using SixLabors.Fonts;
-using JustDanceEditor.Logging;
 
 namespace JustDanceEditor.Converter.Converters.Images;
 
@@ -16,17 +18,14 @@ public static class CoverArtGenerator
         string[] paths =
         [
             Path.Combine(convert.FileSystem.InputFolders.MenuArtFolder, "cover.png"),
-            Path.Combine(convert.FileSystem.InputFolders.MenuArtFolder, $"{convert.SongData.Name}_cover_online.tga.png"),
-            Path.Combine(convert.FileSystem.InputFolders.MenuArtFolder, $"{convert.SongData.Name}_cover_generic.tga.png")
+            Path.Combine(convert.FileSystem.InputFolders.MenuArtFolder, $"{convert.SongData.Name}_cover_online.png"),
+            Path.Combine(convert.FileSystem.InputFolders.MenuArtFolder, $"{convert.SongData.Name}_cover_generic.png")
         ];
 
-        foreach (string path in paths)
+        foreach (string relativePath in paths)
         {
-            if (!File.Exists(path))
-                continue;
-
-            // If the hash is "39c8e22496850ada4b849b0d28d76936", skip it
-            if (Helpers.Download.GetFileMD5(path) == "39c8e22496850ada4b849b0d28d76936")
+            //convert.FileSystem.GetFilePath(path);
+            if (!convert.FileSystem.GetFilePath(relativePath, out CookedFile? path))
                 continue;
 
             Image<Rgba32>? image = TryLoadImage(path);

--- a/JustDanceEditor.Converter/Converters/Images/CoverArtGenerator.cs
+++ b/JustDanceEditor.Converter/Converters/Images/CoverArtGenerator.cs
@@ -24,7 +24,6 @@ public static class CoverArtGenerator
 
         foreach (string relativePath in paths)
         {
-            //convert.FileSystem.GetFilePath(path);
             if (!convert.FileSystem.GetFilePath(relativePath, out CookedFile? path))
                 continue;
 

--- a/JustDanceEditor.Converter/Converters/Images/MenuArtConverter.cs
+++ b/JustDanceEditor.Converter/Converters/Images/MenuArtConverter.cs
@@ -10,7 +10,7 @@ public static class MenuArtConverter
         await Task.Run(() => ConvertMenuArt(convert));
     public static void ConvertMenuArt(ConvertUbiArtToUnity convert)
     {
-        string[] menuArtFiles = Directory.GetFiles(convert.MenuArtFolder);
+        string[] menuArtFiles = Directory.GetFiles(convert.FileSystem.InputFolders.MenuArtFolder);
         Stopwatch stopwatch = Stopwatch.StartNew();
 
         Logger.Log($"Converting {menuArtFiles.Length} menu art files...");
@@ -20,7 +20,7 @@ public static class MenuArtConverter
             try
             {
                 string fileName = Path.GetFileNameWithoutExtension(item);
-                TextureConverter.TextureConverter.ExtractToPNG(item, Path.Combine(convert.TempMenuArtFolder, fileName + ".png"));
+                TextureConverter.TextureConverter.ExtractToPNG(item, Path.Combine(convert.FileSystem.TempFolders.PictoFolder, fileName + ".png"));
             }
             catch (Exception ex)
             {

--- a/JustDanceEditor.Converter/Converters/Images/PictoConverter.cs
+++ b/JustDanceEditor.Converter/Converters/Images/PictoConverter.cs
@@ -20,13 +20,13 @@ public static class PictoConverter
         PictogramClip[] pictoClips = convert.SongData.Clips.OfType<PictogramClip>().ToArray();
 
         // Before starting on the mapPackage, prepare the pictos
-        if (!Directory.Exists(inputFolders.PictosFolder))
+        if (!convert.FileSystem.GetFolderPath(inputFolders.PictosFolder, out string? pictosFolder))
         {
             Logger.Log("Pictos folder doesn't exist, skipping picto conversion", LogLevel.Warning);
             return ([], []);
         }
 
-        string[] pictoFiles = Directory.GetFiles(inputFolders.PictosFolder);
+        string[] pictoFiles = Directory.GetFiles(pictosFolder);
 
         if (pictoFiles.Length == 0)
         {

--- a/JustDanceEditor.Converter/Converters/Video/VideoConverter.cs
+++ b/JustDanceEditor.Converter/Converters/Video/VideoConverter.cs
@@ -64,13 +64,13 @@ public static class VideoConverter
     static string GetVideoFile(ConvertUbiArtToUnity convert)
     {
         string[] videofiles = [];
-        if (Directory.Exists(convert.FileSystem.InputFolders.MediaFolder))
-            videofiles = Directory.GetFiles(convert.FileSystem.InputFolders.MediaFolder, "*.webm");
+        if (convert.FileSystem.GetFolderPath(convert.FileSystem.InputFolders.MediaFolder, out string? mediaFolder))
+            videofiles = Directory.GetFiles(mediaFolder, "*.webm");
         if (videofiles.Length > 0)
             return videofiles[0];
 
-        if (Directory.Exists(Path.Combine(convert.FileSystem.InputFolders.MapWorldFolder, "videoscoach")))
-            videofiles = Directory.GetFiles(Path.Combine(convert.FileSystem.InputFolders.MapWorldFolder, "videoscoach"), "*.webm");
+        if (convert.FileSystem.GetFolderPath(Path.Combine(convert.FileSystem.InputFolders.MapWorldFolder, "videoscoach"), out string? coachFolder))
+            videofiles = Directory.GetFiles(coachFolder, "*.webm");
         if (videofiles.Length > 0)
             return videofiles[0];
 

--- a/JustDanceEditor.Converter/Converters/Video/VideoConverter.cs
+++ b/JustDanceEditor.Converter/Converters/Video/VideoConverter.cs
@@ -28,8 +28,8 @@ public static class VideoConverter
             else
             {
                 Logger.Log("Video file is already in the correct format");
-                Directory.CreateDirectory(convert.TempVideoFolder);
-                File.Copy(videoFile, Path.Combine(convert.TempVideoFolder, "output.webm"), true);
+                Directory.CreateDirectory(convert.FileSystem.TempFolders.VideoFolder);
+                File.Copy(videoFile, Path.Combine(convert.FileSystem.TempFolders.VideoFolder, "output.webm"), true);
             }
         }
         catch (Exception e)
@@ -41,19 +41,19 @@ public static class VideoConverter
         try
         {
             // Now generate the preview video
-            GeneratePreviewVideo(convert, Path.Combine(convert.TempVideoFolder, "output.webm"));
+            GeneratePreviewVideo(convert, Path.Combine(convert.FileSystem.TempFolders.VideoFolder, "output.webm"));
 
             // Move the video file to the output folder
-            string md5 = Download.GetFileMD5(Path.Combine(convert.TempVideoFolder, "output.webm"));
-            string outputVideoPath = Path.Combine(convert.OutputXFolder, "Video_HIGH_vp9_webm");
+            string md5 = Download.GetFileMD5(Path.Combine(convert.FileSystem.TempFolders.VideoFolder, "output.webm"));
+            string outputVideoPath = convert.FileSystem.OutputFolders.VideoFolder;
             Directory.CreateDirectory(outputVideoPath);
-            File.Move(Path.Combine(convert.TempVideoFolder, "output.webm"), Path.Combine(outputVideoPath, md5), true);
+            File.Move(Path.Combine(convert.FileSystem.TempFolders.VideoFolder, "output.webm"), Path.Combine(outputVideoPath, md5), true);
 
             // Move the preview video to the output folder
-            md5 = Download.GetFileMD5(Path.Combine(convert.TempVideoFolder, "preview.webm"));
-            string previewVideoPath = Path.Combine(convert.Output0Folder, "VideoPreview_MID_vp9_webm");
+            md5 = Download.GetFileMD5(Path.Combine(convert.FileSystem.TempFolders.VideoFolder, "preview.webm"));
+            string previewVideoPath = convert.FileSystem.OutputFolders.PreviewVideoFolder;
             Directory.CreateDirectory(previewVideoPath);
-            File.Move(Path.Combine(convert.TempVideoFolder, "preview.webm"), Path.Combine(previewVideoPath, md5));
+            File.Move(Path.Combine(convert.FileSystem.TempFolders.VideoFolder, "preview.webm"), Path.Combine(previewVideoPath, md5));
         }
         catch (Exception e)
         {
@@ -64,13 +64,13 @@ public static class VideoConverter
     static string GetVideoFile(ConvertUbiArtToUnity convert)
     {
         string[] videofiles = [];
-        if (Directory.Exists(convert.InputMediaFolder))
-            videofiles = Directory.GetFiles(convert.InputMediaFolder, "*.webm");
+        if (Directory.Exists(convert.FileSystem.InputFolders.MediaFolder))
+            videofiles = Directory.GetFiles(convert.FileSystem.InputFolders.MediaFolder, "*.webm");
         if (videofiles.Length > 0)
             return videofiles[0];
 
-        if (Directory.Exists(Path.Combine(convert.WorldFolder, "videoscoach")))
-            videofiles = Directory.GetFiles(Path.Combine(convert.WorldFolder, "videoscoach"), "*.webm");
+        if (Directory.Exists(Path.Combine(convert.FileSystem.InputFolders.MapWorldFolder, "videoscoach")))
+            videofiles = Directory.GetFiles(Path.Combine(convert.FileSystem.InputFolders.MapWorldFolder, "videoscoach"), "*.webm");
         if (videofiles.Length > 0)
             return videofiles[0];
 
@@ -92,7 +92,7 @@ public static class VideoConverter
             Logger.Log($"Failed to convert video file, copying as is: {e.Message}", LogLevel.Warning);
 
             // Copy the file as is
-            File.Copy(path, Path.Combine(convert.TempVideoFolder, "output.webm"), true);
+            File.Copy(path, Path.Combine(convert.FileSystem.TempFolders.VideoFolder, "output.webm"), true);
         }
 
         stopwatch.Stop();
@@ -107,7 +107,7 @@ public static class VideoConverter
         float startTime = convert.SongData.GetPreviewStartTime(false);
 
         // Generate the preview video file
-        string previewVideoPath = Path.Combine(convert.TempVideoFolder, "preview.webm");
+        string previewVideoPath = Path.Combine(convert.FileSystem.TempFolders.VideoFolder, "preview.webm");
 
         GeneratePreviewVideoFFmpeg(path, previewVideoPath, startTime);
 
@@ -177,7 +177,7 @@ public static class VideoConverter
             .AddParameter("-crf 4")
             .AddParameter("-b:v 4M")
             .SetOverwriteOutput(true)
-            .SetOutput(Path.Combine(convert.TempVideoFolder, "output.webm"));
+            .SetOutput(Path.Combine(convert.FileSystem.TempFolders.VideoFolder, "output.webm"));
 
         FFMpegProgress progress = new("Video");
         conversion.OnProgress += (sender, args) => progress.Update(args);

--- a/JustDanceEditor.Converter/Files/CookedFile.cs
+++ b/JustDanceEditor.Converter/Files/CookedFile.cs
@@ -24,12 +24,11 @@ public class CookedFile
     public string Extension { get; private set; }
     public bool IsCooked { get; private set; }
 
-    public string GetFullPath()
-    {
-        return (string)this;
-    }
+    public string FullPath => this;
+    public string UncookedPath => DirectoryPath + Name + Extension;
 
-    public static explicit operator string(CookedFile v) => v.ToString();
+
+    public static implicit operator string(CookedFile v) => v.ToString();
 
     public override string ToString()
     {

--- a/JustDanceEditor.Converter/Files/CookedFile.cs
+++ b/JustDanceEditor.Converter/Files/CookedFile.cs
@@ -1,0 +1,43 @@
+﻿
+namespace JustDanceEditor.Converter.Files;
+
+public class CookedFile
+{
+    public CookedFile(string path)
+    {
+        DirectoryPath = Path.GetDirectoryName(path) + Path.DirectorySeparatorChar;
+        string inputFileName = Path.GetFileName(path);
+        Extension = Path.GetExtension(inputFileName);
+
+        if (Extension == ".ckd")
+        {
+            IsCooked = true;
+            inputFileName = Path.GetFileNameWithoutExtension(inputFileName);
+            Extension = Path.GetExtension(inputFileName);
+        }
+
+        Name = Path.GetFileNameWithoutExtension(inputFileName);
+    }
+
+    public string DirectoryPath { get; private set; }
+    public string Name { get; private set; }
+    public string Extension { get; private set; }
+    public bool IsCooked { get; private set; }
+
+    public string GetFullPath()
+    {
+        return (string)this;
+    }
+
+    public static explicit operator string(CookedFile v) => v.ToString();
+
+    public override string ToString()
+    {
+        string fullPath = DirectoryPath + Name + Extension;
+
+        if (IsCooked)
+            fullPath += ".ckd";
+
+        return fullPath;
+    }
+}

--- a/JustDanceEditor.Converter/Files/FileSystem.cs
+++ b/JustDanceEditor.Converter/Files/FileSystem.cs
@@ -86,7 +86,7 @@ public partial class FileSystem
             Logger.Log($"Platform: {PlatformType}");
     }
 
-    public bool GetFilePath(string relativeFilePath, [MaybeNullWhen(false)] out string filePath)
+    public bool GetFilePath(string relativeFilePath, [MaybeNullWhen(false)] out CookedFile filePath)
     {
         filePath = null;
         string parentFolder = Path.Combine(InputFolders.InputFolder, "..");
@@ -121,7 +121,7 @@ public partial class FileSystem
                 string file = Path.Combine(location, relativeFilePath);
                 if (File.Exists(file))
                 {
-                    filePath = file;
+                    filePath = new(file);
                     return true;
                 }
 
@@ -131,7 +131,7 @@ public partial class FileSystem
                 file = Path.Combine(location, pathCooked);
                 if (File.Exists(file))
                 {
-                    filePath = file;
+                    filePath = new(file);
                     return true;
                 }
             }
@@ -140,9 +140,9 @@ public partial class FileSystem
         return false;
     }
 
-    public string GetFilePath(string relativeFilePath)
+    public CookedFile GetFilePath(string relativeFilePath)
     {
-        return GetFilePath(relativeFilePath, out string? filePath)
+        return GetFilePath(relativeFilePath, out CookedFile? filePath)
             ? filePath
             : throw new FileNotFoundException($"The file {relativeFilePath} was not found in the input folders.");
     }

--- a/JustDanceEditor.Converter/Files/FileSystem.cs
+++ b/JustDanceEditor.Converter/Files/FileSystem.cs
@@ -190,8 +190,8 @@ public partial class FileSystem
             : throw new DirectoryNotFoundException($"The folder {relativeFolderPath} was not found in the input folders.");
     }
 
-    public static string ReadWithoutNulls(string filePath)
+    public static string ReadWithoutNull(string filePath)
     {
-        return File.ReadAllText(filePath).Replace("\0", "");
+        return File.ReadAllText(filePath).TrimEnd('\0');
     }
 }

--- a/JustDanceEditor.Converter/Files/FileSystem.cs
+++ b/JustDanceEditor.Converter/Files/FileSystem.cs
@@ -1,0 +1,197 @@
+﻿using JustDanceEditor.Logging;
+
+using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
+
+namespace JustDanceEditor.Converter.Files;
+
+public partial class FileSystem
+{
+    public FileSystem(ConversionRequest conversionRequest)
+    {
+        ConversionRequest = conversionRequest;
+
+        // Get the song ID
+        InitializeSongID();
+
+        // Get the platform type
+        InitializePlatformType();
+
+        // Create the temporary folders
+        TempFolders = new(this);
+        TempFolders.CreateTempFolders();
+
+        // Create the output folders
+        OutputFolders = new(this);
+
+        // Load the template files
+        TemplateFiles = new(this);
+
+        // Load the input folders
+        InputFolders = new(this);
+    }
+
+    public ConversionRequest ConversionRequest { get; private set; }
+
+    public string SongName { get; private set; } = "";
+    public string PlatformType { get; private set; } = "";
+
+    public TempFolders TempFolders { get; private set; }
+    public InputFolders InputFolders { get; private set; }
+    public OutputFolders OutputFolders { get; private set; }
+    public TemplateFiles TemplateFiles { get; private set; }
+
+    private void InitializeSongID()
+    {
+        if (ConversionRequest.SongName != null)
+            SongName = ConversionRequest.SongName;
+        else
+        {
+            // Get the folders from input/world/maps
+            string mapsFolder = Path.Combine(ConversionRequest.InputPath, "world", "maps");
+            if (!Directory.Exists(mapsFolder))
+                throw new DirectoryNotFoundException("The maps folder does not exist.");
+
+            string[] songs = Directory.GetDirectories(mapsFolder);
+            if (songs.Length < 1)
+                throw new DirectoryNotFoundException("No song folders found in the maps folder.");
+            if (songs.Length > 1)
+                throw new DirectoryNotFoundException("Multiple song folders found in the maps folder, please specify the song name in the request.");
+
+            SongName = Path.GetFileName(songs[0]);
+        }
+
+        Logger.Log($"Song name: {SongName}", LogLevel.Important);
+    }
+
+    private void InitializePlatformType()
+    {
+        string itfCookedFolder = Path.Combine(ConversionRequest.InputPath, "cache", "itf_cooked");
+
+        if (!Directory.Exists(itfCookedFolder))
+            throw new DirectoryNotFoundException("The itf_cooked folder does not exist.");
+
+        string[] platformFolders = Directory.GetDirectories(itfCookedFolder);
+
+        if (platformFolders.Length == 0)
+            throw new DirectoryNotFoundException("No platform folders found in the itf_cooked folder.");
+        if (platformFolders.Length > 1)
+            throw new DirectoryNotFoundException("Multiple platform folders found in the itf_cooked folder, this is not supported.");
+
+        PlatformType = Path.GetFileName(platformFolders[0]);
+
+        if (!PlatformType.Equals("nx", StringComparison.CurrentCultureIgnoreCase))
+            Logger.Log($"Platform: {PlatformType}, which is not officially supported. The conversion might not work as expected.", LogLevel.Warning);
+        else
+            Logger.Log($"Platform: {PlatformType}");
+    }
+
+    public bool GetFilePath(string relativeFilePath, [MaybeNullWhen(false)] out string filePath)
+    {
+        filePath = null;
+        string parentFolder = Path.Combine(InputFolders.InputFolder, "..");
+        List<string> searchPaths = [
+            Path.Combine(parentFolder, $"patch_{PlatformType}"),
+            InputFolders.InputFolder,
+            Path.Combine(parentFolder, $"bundle_{PlatformType}"),
+            ];
+
+        foreach (string searchPath in Directory.GetDirectories(parentFolder))
+            if (!searchPaths.Contains(searchPath))
+                searchPaths.Add(searchPath);
+
+        string? pathCooked = null;
+
+        if (Path.GetExtension(relativeFilePath) != ".ckd")
+        {
+            pathCooked = $"{relativeFilePath}.ckd";
+        }
+
+        // For each path, check if the file exists
+        foreach (string searchPath in searchPaths)
+        {
+            string[] searchLocations = [
+                searchPath,
+                Path.Combine(searchPath, "cache", "itf_cooked", PlatformType)
+                ];
+
+            foreach (string location in searchLocations)
+            {
+
+                string file = Path.Combine(location, relativeFilePath);
+                if (File.Exists(file))
+                {
+                    filePath = file;
+                    return true;
+                }
+
+                if (pathCooked == null)
+                    continue;
+
+                file = Path.Combine(location, pathCooked);
+                if (File.Exists(file))
+                {
+                    filePath = file;
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+
+    public string GetFilePath(string relativeFilePath)
+    {
+        return GetFilePath(relativeFilePath, out string? filePath)
+            ? filePath
+            : throw new FileNotFoundException($"The file {relativeFilePath} was not found in the input folders.");
+    }
+
+    public bool GetFolderPath(string relativeFolderPath, [MaybeNullWhen(false)] out string folderPath)
+    {
+        folderPath = null;
+        string parentFolder = Path.Combine(InputFolders.InputFolder, "..");
+
+        List<string> searchPaths = [
+            Path.Combine(parentFolder, $"patch_{PlatformType}"),
+            InputFolders.InputFolder,
+            Path.Combine(parentFolder, $"bundle_{PlatformType}"),
+            ];
+
+        foreach (string searchPath in Directory.GetDirectories(parentFolder))
+            if (!searchPaths.Contains(searchPath))
+                searchPaths.Add(searchPath);
+
+        // For each path, check if the folder exists
+        foreach (string searchPath in searchPaths)
+        {
+            string[] searchLocations = [
+                searchPath,
+                Path.Combine(searchPath, "cache", "itf_cooked", PlatformType)
+                ];
+            foreach (string location in searchLocations)
+            {
+                string folder = Path.Combine(location, relativeFolderPath);
+                if (Directory.Exists(folder))
+                {
+                    folderPath = folder;
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+
+    public string GetFolderPath(string relativeFolderPath)
+    {
+        return GetFolderPath(relativeFolderPath, out string? folderPath)
+            ? folderPath
+            : throw new DirectoryNotFoundException($"The folder {relativeFolderPath} was not found in the input folders.");
+    }
+
+    public static string ReadWithoutNulls(string filePath)
+    {
+        return File.ReadAllText(filePath).Replace("\0", "");
+    }
+}

--- a/JustDanceEditor.Converter/Files/InputFolders.cs
+++ b/JustDanceEditor.Converter/Files/InputFolders.cs
@@ -1,0 +1,25 @@
+﻿namespace JustDanceEditor.Converter.Files;
+
+public class InputFolders
+{
+    public InputFolders(FileSystem fileSystem)
+    {
+        this.fileSystem = fileSystem;
+    }
+
+    readonly FileSystem fileSystem;
+    public string InputFolder => fileSystem.ConversionRequest.InputPath;
+
+
+    public string MapCacheFolder => Path.Combine("cache", "itf_cooked", fileSystem.PlatformType, "world", "maps", fileSystem.SongName);
+    public string MapWorldFolder => Path.Combine("world", "maps", fileSystem.SongName);
+
+    public string MediaFolder => Path.Combine(MapWorldFolder, "media");
+
+    public string AudioFolder => Path.Combine(MapCacheFolder, "audio");
+    public string MenuArtFolder => Path.Combine(MapCacheFolder, "menuart", "textures");
+    public string TimelineFolder => Path.Combine(MapCacheFolder, "timeline", fileSystem.SongName);
+    public string PictosFolder => Path.Combine(TimelineFolder, "pictos");
+    // WiiU is hardcoded here, but should be a variable, NX => WiiU, rest idk
+    public string MovesFolder => Path.Combine(MapWorldFolder, "timeline", "moves", "wiiu");
+}

--- a/JustDanceEditor.Converter/Files/InputFolders.cs
+++ b/JustDanceEditor.Converter/Files/InputFolders.cs
@@ -10,15 +10,13 @@ public class InputFolders
     readonly FileSystem fileSystem;
     public string InputFolder => fileSystem.ConversionRequest.InputPath;
 
-
-    public string MapCacheFolder => Path.Combine("cache", "itf_cooked", fileSystem.PlatformType, "world", "maps", fileSystem.SongName);
     public string MapWorldFolder => Path.Combine("world", "maps", fileSystem.SongName);
 
     public string MediaFolder => Path.Combine(MapWorldFolder, "media");
 
-    public string AudioFolder => Path.Combine(MapCacheFolder, "audio");
-    public string MenuArtFolder => Path.Combine(MapCacheFolder, "menuart", "textures");
-    public string TimelineFolder => Path.Combine(MapCacheFolder, "timeline", fileSystem.SongName);
+    public string AudioFolder => Path.Combine(MapWorldFolder, "audio");
+    public string MenuArtFolder => Path.Combine(MapWorldFolder, "menuart", "textures");
+    public string TimelineFolder => Path.Combine(MapWorldFolder, "timeline");
     public string PictosFolder => Path.Combine(TimelineFolder, "pictos");
     // WiiU is hardcoded here, but should be a variable, NX => WiiU, rest idk
     public string MovesFolder => Path.Combine(MapWorldFolder, "timeline", "moves", "wiiu");

--- a/JustDanceEditor.Converter/Files/OutputFolders.cs
+++ b/JustDanceEditor.Converter/Files/OutputFolders.cs
@@ -1,0 +1,82 @@
+﻿using JustDanceEditor.Logging;
+using System.Globalization;
+
+namespace JustDanceEditor.Converter.Files;
+
+public class OutputFolders
+{
+    public OutputFolders(FileSystem fileSystem)
+    {
+        this.fileSystem = fileSystem;
+        CacheNumber = InitializeCacheNumber();
+    }
+
+    readonly FileSystem fileSystem;
+
+    public uint CacheNumber { get; set; } = 123;
+
+    public string OutputFolder => Path.Combine(fileSystem.ConversionRequest.OutputPath, fileSystem.SongName);
+
+    public string PreviewFolder => Path.Combine(OutputFolder, $"SD_Cache.0000", "MapBaseCache", fileSystem.ConversionRequest.SongGUID);
+    public string CoverFolder => Path.Combine(PreviewFolder, "Cover");
+    public string PreviewAudioFolder => Path.Combine(PreviewFolder, "AudioPreview_opus");
+    public string PreviewVideoFolder => Path.Combine(PreviewFolder, "VideoPreview_MID_vp9_webm");
+
+
+    public string MapFolder => Path.Combine(OutputFolder, $"SD_Cache.{CacheNumber:X4}", fileSystem.ConversionRequest.SongGUID);
+    public string AudioFolder => Path.Combine(MapFolder, "Audio");
+    public string CoachesLargeFolder => Path.Combine(MapFolder, "CoachesLarge");
+    public string CoachesSmallFolder => Path.Combine(MapFolder, "CoachesSmall");
+    public string MapPackageFolder => Path.Combine(MapFolder, "MapPackage");
+    public string SongTitleLogoFolder => Path.Combine(MapFolder, "SongTitleLogo");
+    public string VideoFolder => Path.Combine(MapFolder, "Video_HIGH_vp9_webm");
+
+    public string CachingStatusPath => Path.Combine(PreviewFolder, "CachingStatus.json");
+    public string CachePath => Path.Combine(OutputFolder, "Cache.json");
+
+    private uint InitializeCacheNumber()
+    {
+        string cachingStatusPath = Path.Combine(fileSystem.ConversionRequest.OutputPath, "SD_Cache.0000", "MapBaseCache", "cachingStatus.json");
+
+        // If the cache number is provided, use it
+        if (fileSystem.ConversionRequest.CacheNumber != null)
+            return (uint)fileSystem.ConversionRequest.CacheNumber;
+
+        // If we're not in a real cache folder, just use 123
+        else if (!File.Exists(cachingStatusPath))
+        {
+            Logger.Log("Setting cache number to 123", LogLevel.Important);
+            return 123;
+        }
+
+        // We're in a real cache folder, let's find the max cache number
+        // Get all the directories in the output path formatted as SD_Cache.xxxx
+        string[] directories = Directory.GetDirectories(fileSystem.ConversionRequest.OutputPath);
+
+        uint maxCacheNumber = 1;
+        uint CacheNumber;
+
+        foreach (string directory in directories)
+        {
+            // If the directory is SD_Cache.0000, skip it
+            if (Path.GetFileName(directory).Equals("SD_Cache.0000", StringComparison.CurrentCultureIgnoreCase))
+                continue;
+
+            if (directory.Contains("SD_Cache.") && uint.TryParse(directory.Split('.').Last(), NumberStyles.HexNumber, CultureInfo.InvariantCulture, out uint cacheNumber))
+                maxCacheNumber = Math.Max(maxCacheNumber, cacheNumber);
+        }
+
+        // Create the new cache folder
+        Directory.CreateDirectory(Path.Combine(fileSystem.ConversionRequest.OutputPath, $"SD_Cache.{maxCacheNumber:X4}"));
+
+        // If the folder of the max cache number is over 2.8 GB, we'll start a new one
+        long cacheSize = new DirectoryInfo(Path.Combine(fileSystem.ConversionRequest.OutputPath, $"SD_Cache.{maxCacheNumber:X4}")).EnumerateFiles("*", SearchOption.AllDirectories).Sum(f => f.Length);
+
+        CacheNumber = cacheSize > 2.8f * 1024 * 1024 * 1024
+            ? maxCacheNumber + 1
+            : maxCacheNumber;
+
+        Logger.Log($"Setting cache number to {CacheNumber}", LogLevel.Important);
+        return CacheNumber;
+    }
+}

--- a/JustDanceEditor.Converter/Files/TempFolders.cs
+++ b/JustDanceEditor.Converter/Files/TempFolders.cs
@@ -1,0 +1,42 @@
+﻿using JustDanceEditor.Logging;
+
+namespace JustDanceEditor.Converter.Files;
+
+public class TempFolders(FileSystem fileSystem)
+{
+    readonly FileSystem filseSystem = fileSystem;
+
+    // Temporary folders
+    public string MapFolder => Path.Combine(Path.GetTempPath(), "JustDanceEditor", filseSystem.SongName);
+    public string PictoFolder => Path.Combine(MapFolder, "pictos");
+    public string PictoAtlasFolder => Path.Combine(PictoFolder, "Atlas");
+    public string MenuArtFolder => Path.Combine(MapFolder, "menuart");
+    public string AudioFolder => Path.Combine(MapFolder, "audio");
+    public string VideoFolder => Path.Combine(MapFolder, "video");
+
+    public void CreateTempFolders()
+    {
+        // Delete the old temp folder
+        if (Directory.Exists(MapFolder))
+        {
+            Logger.Log("Deleting the old temp folder", LogLevel.Debug);
+            Directory.Delete(MapFolder, true);
+        }
+
+        // Create the folders
+        Logger.Log("Creating temp folders", LogLevel.Debug);
+        Directory.CreateDirectory(MapFolder);
+        Directory.CreateDirectory(PictoFolder);
+        Directory.CreateDirectory(PictoAtlasFolder);
+        Directory.CreateDirectory(MenuArtFolder);
+        Directory.CreateDirectory(AudioFolder);
+        Directory.CreateDirectory(VideoFolder);
+    }
+
+    public void Delete()
+    {
+        // Delete the temp folder
+        Logger.Log("Deleting the temp folder", LogLevel.Debug);
+        Directory.Delete(MapFolder, true);
+    }
+}

--- a/JustDanceEditor.Converter/Files/TemplateFiles.cs
+++ b/JustDanceEditor.Converter/Files/TemplateFiles.cs
@@ -1,0 +1,21 @@
+﻿using System;
+
+namespace JustDanceEditor.Converter.Files;
+
+public class TemplateFiles
+{
+    public TemplateFiles(FileSystem fileSystem)
+    {
+        this.fileSystem = fileSystem;
+    }
+
+    readonly FileSystem fileSystem;
+
+    public string TemplateFolder => fileSystem.ConversionRequest.TemplatePath;
+
+    public string CoachesLarge => Directory.GetFiles(Path.Combine(TemplateFolder, "CoachesLarge"))[0];
+    public string CoachesSmall => Directory.GetFiles(Path.Combine(TemplateFolder, "CoachesSmall"))[0];
+    public string Cover => Directory.GetFiles(Path.Combine(TemplateFolder, "Cover"))[0];
+    public string MapPackage => Directory.GetFiles(Path.Combine(TemplateFolder, "MapPackage"))[0];
+    public string SongTitleLogo => Directory.GetFiles(Path.Combine(TemplateFolder, "SongTitleLogo"))[0];
+}

--- a/JustDanceEditor.Converter/UbiArt/ISC.cs
+++ b/JustDanceEditor.Converter/UbiArt/ISC.cs
@@ -1,0 +1,35 @@
+﻿using System.Diagnostics.CodeAnalysis;
+using System.Xml.Linq;
+
+namespace JustDanceEditor.Converter.UbiArt;
+
+public static class ISC
+{
+    public static bool GetActorPath(string input, string actorName, [MaybeNullWhen(false)] out string actorPath)
+    {
+        actorPath = null;
+
+        // Return false if the actor path is not found
+        if (Path.Exists(input) == false)
+            return false;
+
+        // Load the XML from the file
+        XDocument xmlDoc = XDocument.Load(input);
+
+        foreach (XElement actor in xmlDoc.Descendants("Actor"))
+        {
+            XAttribute? attribute = actor.Attribute("USERFRIENDLY");
+            if (attribute != null && (string)attribute == actorName)
+            {
+                XAttribute? luaAttribute = actor.Attribute("LUA");
+                if (luaAttribute != null)
+                {
+                    actorPath = (string)luaAttribute;
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+}

--- a/JustDanceEditor.Converter/UbiArt/JDUbiArtSong.cs
+++ b/JustDanceEditor.Converter/UbiArt/JDUbiArtSong.cs
@@ -9,7 +9,7 @@ public class JDUbiArtSong
     public uint CoachCount { get => SongDesc.COMPONENTS[0].NumCoach; set => SongDesc.COMPONENTS[0].NumCoach = value; }
     public JDVersion EngineVersion = JDVersion.Unknown;
     public JDVersion JDVersion = JDVersion.Unknown;
-    public IClip[] Clips { get; set; } = [];
+    public List<IClip> Clips { get; set; } = [];
     public MusicTrack MusicTrack { get; set; } = new();
     public SongDesc SongDesc { get; set; } = new();
 

--- a/JustDanceEditor.Converter/UbiArt/Tapes/Clips/ClipConverter.cs
+++ b/JustDanceEditor.Converter/UbiArt/Tapes/Clips/ClipConverter.cs
@@ -16,19 +16,11 @@ public class ClipConverter : JsonConverter<IClip>
         }
 
         string className = classNameElement.GetString()!;
+        Type? type = Type.GetType($"JustDanceEditor.Converter.UbiArt.Tapes.Clips.{className}");
 
-        return className switch
-        {
-            "GoldEffectClip" => JsonSerializer.Deserialize<GoldEffectClip>(root.GetRawText(), options)!,
-            "HideUserInterfaceClip" => JsonSerializer.Deserialize<HideUserInterfaceClip>(root.GetRawText(), options)!,
-            "KaraokeClip" => JsonSerializer.Deserialize<KaraokeClip>(root.GetRawText(), options)!,
-            "MotionClip" => JsonSerializer.Deserialize<MotionClip>(root.GetRawText(), options)!,
-            "PictogramClip" => JsonSerializer.Deserialize<PictogramClip>(root.GetRawText(), options)!,
-            "SoundSetClip" => JsonSerializer.Deserialize<SoundSetClip>(root.GetRawText(), options)!,
-            "VibrationClip" => JsonSerializer.Deserialize<VibrationClip>(root.GetRawText(), options)!,
-
-            _ => throw new JsonException($"Unknown clip type: {className}"),
-        };
+        return type == null
+            ? throw new JsonException($"Unknown clip type: {className}")
+            : (IClip)JsonSerializer.Deserialize(root.GetRawText(), type, options)!;
     }
 
     public override void Write(Utf8JsonWriter writer, IClip value, JsonSerializerOptions? options = null)

--- a/JustDanceEditor.Converter/Unity/JDCacheJSON.cs
+++ b/JustDanceEditor.Converter/Unity/JDCacheJSON.cs
@@ -117,8 +117,8 @@ public class SongDatabaseEntry
         float startTime = convert.SongData.MusicTrack.COMPONENTS[0].trackData.structure.markers[startBeat] / 48f / 1000f;
         float endTime = convert.SongData.MusicTrack.COMPONENTS[0].trackData.structure.markers[endBeat] / 48f / 1000f;
 
-        string songTitleLogoPath = Path.Combine(convert.Output0Folder, "songTitleLogo");
-        bool songTitleLogo = Directory.Exists(songTitleLogoPath) && Directory.GetFiles(Path.Combine(convert.Output0Folder, "songTitleLogo")).Length > 0;
+        string songTitleLogoPath = convert.FileSystem.OutputFolders.SongTitleLogoFolder;
+        bool songTitleLogo = Directory.Exists(songTitleLogoPath) && Directory.GetFiles(songTitleLogoPath).Length > 0;
 
         return new()
         {

--- a/JustDanceEditor.Logging/Logger.cs
+++ b/JustDanceEditor.Logging/Logger.cs
@@ -53,6 +53,8 @@ public static class Logger
                 Console.ForegroundColor = ConsoleColor.White;
                 break;
             case LogLevel.Important:
+                Console.ForegroundColor = ConsoleColor.Green;
+                break;
             case LogLevel.Warning:
                 Console.ForegroundColor = ConsoleColor.Yellow;
                 break;

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ The author is not responsible for any misuse of this tool.
 
 ## Usage
 1. Extract the ``ipk`` file of the song you want to convert by drag and dropping it onto ``JustDanceEditor.IPK.exe``.
-2. If the song is a ``mainscene``, in the song folder, create a new folder called ``menuart`` in ``\world\maps\{MapName}\`` and put in the following files:
+2. If the song is a ``mainscene``, in the song folder, place the following files in ``\world\maps\{MapName}\menuart\textures`` (either in ``.png``, ``.png.ckd``, or ``.tga.ckd``):
 	- ``{MapName}_Coach_1.tga.cdk``, ``{MapName}_Coach_2.tga.cdk``, ``{MapName}_Coach_..`` (up to 4 coaches)
 	- ``{MapName}_AlbumCoach.tga.cdk`` or a 1024x2048 ``{MapName}_Cover_Generic.tga``
 	- ``{MapName}_map_bkg.tga``

--- a/TextureConverter/TextureConverter.cs
+++ b/TextureConverter/TextureConverter.cs
@@ -15,6 +15,16 @@ public class TextureConverter
         if (!File.Exists(inputPath))
             throw new FileNotFoundException("Input file not found!", inputPath);
 
+        try
+        {
+            // Try loading the file as an image
+            return Image.Load<Bgra32>(inputPath);
+        }
+        catch (Exception)
+        {
+            // If it's not an image, continue
+        }
+
         // Open stream and read header
         FileStream fileStream = File.OpenRead(inputPath);
         BinaryReader reader = new(fileStream);


### PR DESCRIPTION
#### PR Classification
Code cleanup and refactor to improve maintainability.

#### PR Summary
Refactored code to use a new `FileSystem` class for managing file and folder paths, improving organization and maintainability.
- `ConvertUbiArtToUnity` class updated to use `FileSystem` for file operations.
- Introduced new classes: `CookedFile`, `InputFolders`, `OutputFolders`, `TempFolders`, `TemplateFiles`, and `ISC`.
- `ClipConverter` class now uses reflection to determine clip type.
- `Logger` class updated with a new log level `Important`.
- `README.md` updated for new file locations.
