### PR TITLE
Refactor and simplify code in ConverterDialogue.cs and GTX.cs

### DIFF
--- a/JustDanceEditor.UI/Converting/ConverterDialogue.cs
+++ b/JustDanceEditor.UI/Converting/ConverterDialogue.cs
@@ -156,7 +156,7 @@ public class ConverterDialogue
 
     static string AskMultiInputFolder()
     {
-        string inputPath = "";
+        string inputPath;
         while (true)
         {
             inputPath = Question.AskFolder("Enter the path to the folder containing the cache and world folders", true);


### PR DESCRIPTION
#### PR Classification
Code cleanup and refactoring to improve code readability and maintainability.

#### PR Summary
Refactored and cleaned up code in `ConverterDialogue.cs` and `GTX.cs` to remove unused variables and simplify logic.
- `ConverterDialogue.cs`: Removed unnecessary initialization of `inputPath`.
- `GTX.cs`: Refactored image format check, commented out `GetBPP` call, and removed or commented out several variables and methods (`RestoreSurfaceInfo`, `AdjustSurfaceInfo`).
