### PR TITLE
Be more picky in cover arts

### DIFF
--- a/TextureConverter/TextureConverter.cs
+++ b/TextureConverter/TextureConverter.cs
@@ -15,16 +15,6 @@ public class TextureConverter
         if (!File.Exists(inputPath))
             throw new FileNotFoundException("Input file not found!", inputPath);
 
-        try
-        {
-            // Try loading the file as an image
-            return Image.Load<Bgra32>(inputPath);
-        }
-        catch (Exception)
-        {
-            // If it's not an image, continue
-        }
-
         // Open stream and read header
         FileStream fileStream = File.OpenRead(inputPath);
         BinaryReader reader = new(fileStream);
@@ -46,7 +36,7 @@ public class TextureConverter
             "DDS " => DDS.GetImage(fileStream),
             "DFvN" => XTX.GetImage(fileStream),
             "Gfx2" => GTX.GetImage(fileStream),
-            _ => throw new Exception("Unknown file format!"),
+            _ => Image.Load<Bgra32>(fileStream)
         };
 
         // Close stream and delete original file if needed


### PR DESCRIPTION
#### PR Classification
Code improvement for robustness and simplification.

#### PR Summary
Enhances the robustness of the `TryCoverWeb` method in `CoverArtGenerator.cs` and simplifies file loading in `TextureConverter.cs`.
- `CoverArtGenerator.cs`: Improved `TryCoverWeb` method to handle nested song titles and verify code names on additional pages.
- `TextureConverter.cs`: Simplified file loading by removing try-catch block and using `Image.Load<Bgra32>(fileStream)` for unknown formats.
