### PR TITLE
Fix cache generation and other fixes

### DIFF
--- a/JustDanceEditor.Converter/Converters/Audio/AudioConverter.cs
+++ b/JustDanceEditor.Converter/Converters/Audio/AudioConverter.cs
@@ -150,7 +150,8 @@ public static class AudioConverter
         {
             // Change extension to .wav
             string relativePath = Path.ChangeExtension(audioVibrationClip.SoundSetPath, ".wav");
-            string wavPath = convert.FileSystem.GetFilePath(relativePath);
+            if (!convert.FileSystem.GetFilePath(relativePath, out CookedFile? wavPath))
+                continue;
             string newWavPath = Path.Combine(convert.FileSystem.TempFolders.AudioFolder, Path.GetFileName(wavPath));
             if (!File.Exists(newWavPath))
                 audioConverter.Convert(wavPath, newWavPath).Wait();

--- a/JustDanceEditor.Converter/Converters/Audio/AudioConverter.cs
+++ b/JustDanceEditor.Converter/Converters/Audio/AudioConverter.cs
@@ -152,7 +152,7 @@ public static class AudioConverter
             string relativePath = Path.ChangeExtension(audioVibrationClip.SoundSetPath, ".wav");
             if (!convert.FileSystem.GetFilePath(relativePath, out CookedFile? wavPath))
                 continue;
-            string newWavPath = Path.Combine(convert.FileSystem.TempFolders.AudioFolder, Path.GetFileName(wavPath));
+            string newWavPath = Path.Combine(convert.FileSystem.TempFolders.AudioFolder, wavPath.Name + wavPath.Extension);
             if (!File.Exists(newWavPath))
                 audioConverter.Convert(wavPath, newWavPath).Wait();
         }

--- a/JustDanceEditor.Converter/Converters/Cache/CacheJsonGenerator.cs
+++ b/JustDanceEditor.Converter/Converters/Cache/CacheJsonGenerator.cs
@@ -32,7 +32,7 @@ public static class CacheJsonGenerator
     static void MergeCachesInternal(ConvertUbiArtToUnity convert)
     {
         // First we load the generated JSON
-        string cachingStatusPath = Path.Combine(convert.FileSystem.OutputFolders.OutputFolder, "cachingStatus.json");
+        string cachingStatusPath = convert.FileSystem.OutputFolders.CachePath;
         Dictionary<string, JDSong> caching = JsonSerializer.Deserialize<Dictionary<string, JDSong>>(File.ReadAllText(cachingStatusPath), options)!;
 
         // The one we'll add to is in the existing SD_0000 folder
@@ -74,9 +74,7 @@ public static class CacheJsonGenerator
 
         // If the output folder is empty, remove it
         if (Directory.GetFiles(outputFolder).Length == 0 && Directory.GetDirectories(outputFolder).Length == 0)
-        {
             Directory.Delete(outputFolder);
-        }
     }
 
     static void RecursivelyRemoveEmptyDirectories(string path)
@@ -128,7 +126,7 @@ public static class CacheJsonGenerator
             songTitleLogoName = Path.GetFileName(Directory.GetFiles(outputFolders.SongTitleLogoFolder)[0]);
         }
 
-        string cachingStatusPath = Path.Combine(outputFolders.OutputFolder, "cachingStatus.json");
+        string cachingStatusPath = convert.FileSystem.OutputFolders.CachePath;
         JDSong jdSong = JDSongFactory.CreateSong((SongDatabaseEntry)convert, cacheNumber, coverName, coachesSmallName, coachesLargeName, audioPreviewName, videoPreviewName, audioName, videoName, mapPackageName, songTitleLogoName, convert.SongID);
 
         Dictionary<string, JDSong> caching = new()

--- a/JustDanceEditor.Converter/Converters/ConvertUbiArtToUnity.cs
+++ b/JustDanceEditor.Converter/Converters/ConvertUbiArtToUnity.cs
@@ -208,7 +208,8 @@ public class ConvertUbiArtToUnity(ConversionRequest conversionRequest)
     async Task ConvertMediaAsync()
     {
         // First, download FFmpeg if needed
-        await FFmpegDownloader.GetLatestVersion(FFmpegVersion.Official);
+        if (!File.Exists("ffmpeg.exe"))
+            await FFmpegDownloader.GetLatestVersion(FFmpegVersion.Official);
 
         // Then, convert the audio and video
         await Task.WhenAll(

--- a/JustDanceEditor.Converter/Converters/Video/VideoConverter.cs
+++ b/JustDanceEditor.Converter/Converters/Video/VideoConverter.cs
@@ -69,8 +69,8 @@ public static class VideoConverter
         if (videofiles.Length > 0)
             return videofiles[0];
 
-        if (convert.FileSystem.GetFolderPath(Path.Combine(convert.FileSystem.InputFolders.MapWorldFolder, "videoscoach"), out string? coachFolder))
-            videofiles = Directory.GetFiles(coachFolder, "*.webm");
+        videofiles = convert.FileSystem.GetAllFiles(Path.Combine(convert.FileSystem.InputFolders.MapWorldFolder, "videoscoach"), "*.webm")
+            .Select(x => (string)x).ToArray();
         if (videofiles.Length > 0)
             return videofiles[0];
 

--- a/JustDanceEditor.Converter/Files/FileSystem.cs
+++ b/JustDanceEditor.Converter/Files/FileSystem.cs
@@ -147,6 +147,35 @@ public partial class FileSystem
             : throw new FileNotFoundException($"The file {relativeFilePath} was not found in the input folders.");
     }
 
+    public CookedFile[] GetAllFiles(string relativeFolderPath, string pattern = "*")
+    {
+        List<CookedFile> files = [];
+        string parentFolder = Path.Combine(InputFolders.InputFolder, "..");
+        string[] searchPaths = Directory.GetDirectories(parentFolder);
+
+        foreach (string searchPath in searchPaths)
+        {
+            string[] searchLocations = [
+                searchPath,
+                Path.Combine(searchPath, "cache", "itf_cooked", PlatformType)
+                ];
+
+            foreach (string location in searchLocations)
+            {
+                string folder = Path.Combine(location, relativeFolderPath);
+                if (Directory.Exists(folder))
+                {
+                    foreach (string file in Directory.GetFiles(folder, pattern))
+                    {
+                        files.Add(new(file));
+                    }
+                }
+            }
+        }
+
+        return [.. files];
+    }
+
     public bool GetFolderPath(string relativeFolderPath, [MaybeNullWhen(false)] out string folderPath)
     {
         folderPath = null;

--- a/JustDanceEditor.Converter/Files/OutputFolders.cs
+++ b/JustDanceEditor.Converter/Files/OutputFolders.cs
@@ -17,7 +17,7 @@ public class OutputFolders
 
     public string OutputFolder => Path.Combine(fileSystem.ConversionRequest.OutputPath, fileSystem.SongName);
 
-    public string PreviewFolder => Path.Combine(OutputFolder, $"SD_Cache.0000", "MapBaseCache", fileSystem.ConversionRequest.SongGUID);
+    public string PreviewFolder => Path.Combine(OutputFolder, "SD_Cache.0000", "MapBaseCache", fileSystem.ConversionRequest.SongGUID);
     public string CoverFolder => Path.Combine(PreviewFolder, "Cover");
     public string PreviewAudioFolder => Path.Combine(PreviewFolder, "AudioPreview_opus");
     public string PreviewVideoFolder => Path.Combine(PreviewFolder, "VideoPreview_MID_vp9_webm");
@@ -31,7 +31,7 @@ public class OutputFolders
     public string SongTitleLogoFolder => Path.Combine(MapFolder, "SongTitleLogo");
     public string VideoFolder => Path.Combine(MapFolder, "Video_HIGH_vp9_webm");
 
-    public string CachingStatusPath => Path.Combine(PreviewFolder, "CachingStatus.json");
+    public string CachingStatusPath => Path.Combine(OutputFolder, "..", "SD_Cache.0000", "MapBaseCache", "CachingStatus.json");
     public string CachePath => Path.Combine(OutputFolder, "Cache.json");
 
     private uint InitializeCacheNumber()


### PR DESCRIPTION
#### PR Classification
Code cleanup and error prevention.

#### PR Summary
Refactored file path handling and added checks to prevent errors and redundant operations.
- **AudioConverter.cs**: Added file existence check before retrieving file paths.
- **CacheJsonGenerator.cs**: Simplified path construction and removed redundant braces.
- **ConvertUbiArtToUnity.cs**: Added check for `ffmpeg.exe` existence before downloading.
- **MenuArtConverter.cs**: Changed file retrieval to use `CookedFile` objects.
- **FileSystem.cs**: Added `GetAllFiles` method to retrieve files matching a pattern.
