### PR TITLE
Add trivial bundle generation for covers and logos

### DIFF
--- a/JustDanceEditor.Converter/Converters/Bundles/CoverBundleGenerator.cs
+++ b/JustDanceEditor.Converter/Converters/Bundles/CoverBundleGenerator.cs
@@ -8,6 +8,7 @@ using JustDanceEditor.Logging;
 
 using SixLabors.ImageSharp;
 using SixLabors.ImageSharp.PixelFormats;
+using SixLabors.ImageSharp.Processing;
 
 using TextureConverter;
 using TextureConverter.TextureConverterHelpers;
@@ -33,12 +34,49 @@ public static class CoverBundleGenerator
         Logger.Log("Finished generating cover");
     }
 
+    /// <summary>
+    /// Generates a cover bundle from an image path, bypassing the full conversion context.
+    /// </summary>
+    /// <param name="codename">The codename of the song.</param>
+    /// <param name="coverImage">The cover image to use.</param>
+    /// <param name="templatePath">The path to the template cover bundle file.</param>
+    /// <param name="outputFolderPath">The folder where the generated bundle will be saved.</param>
+    /// <param name="forCustomServer">Whether to format the bundle for a custom server.</param>
+    public static void GenerateCover(string codename, Image<Rgba32> coverImage, string templatePath, string outputFolderPath, bool forCustomServer)
+    {
+        try
+        {
+            Logger.Log($"Starting trivial generation for cover: {codename}");
+
+            // Resize the image to 640x360
+            coverImage.Mutate(x => x.Resize(640, 360));
+
+            // Initialize AssetsManager and load bundle data
+            var (Manager, BunInst, AFileInst, AFile, AssetBundleInfo, AssetBundleBase, CoverTextureInfo, CoverSpriteInfo) =
+                InitializeBundle(templatePath, codename);
+
+            // Update the cover texture asset with the new image data
+            UpdateCoverTexture(codename, Manager, AFileInst, CoverTextureInfo, coverImage);
+
+            // Update the cover sprite asset
+            UpdateCoverSprite(codename, Manager, AFileInst, CoverSpriteInfo);
+
+            // Apply all changes to the AssetBundle and save the modified bundle file
+            FinalizeAndSaveBundle(outputFolderPath, forCustomServer, BunInst.file, AFile, AssetBundleBase, AssetBundleInfo.SetNewData);
+
+            Logger.Log($"Finished generating trivial cover for {codename}");
+        }
+        catch (Exception e)
+        {
+            Logger.Log($"Failed to generate trivial cover for {codename}: {e.Message}", LogLevel.Error);
+            throw;
+        }
+    }
+
+
     private static void GenerateCoverInternal(ConversionContext context)
     {
         Logger.Log("Converting Cover...");
-
-        // Initialize AssetsManager and load bundle data
-        var (Manager, BunInst, AFileInst, AFile, AssetBundleInfo, AssetBundleBase, CoverTextureInfo, CoverSpriteInfo) = InitializeBundle(context);
 
         // Prepare the cover image from various sources
         using Image<Rgba32>? coverImage = PrepareCoverImage(context);
@@ -48,22 +86,21 @@ public static class CoverBundleGenerator
             return;
         }
 
-        // Update the cover texture asset with the new image data
-        UpdateCoverTexture(context, Manager, AFileInst, CoverTextureInfo, coverImage);
-
-        // Update the cover sprite asset
-        UpdateCoverSprite(context, Manager, AFileInst, CoverSpriteInfo);
-
-        // Apply all changes to the AssetBundle and save the modified bundle file
-        FinalizeAndSaveBundle(context, BunInst.file, AFile, AssetBundleBase, AssetBundleInfo.SetNewData);
+        // Generate the cover bundle using the prepared image
+        GenerateCover(
+            context.SongData.Name,
+            coverImage,
+            context.FileSystem.TemplateFiles.Cover,
+            context.FileSystem.OutputFolders.CoverFolder,
+            context.Request.ExportType == ExportType.CustomServer
+        );
     }
 
     private static (AssetsManager Manager, BundleFileInstance BunInst, AssetsFileInstance AFileInst, AssetsFile AFile, AssetFileInfo AssetBundleInfo, AssetTypeValueField AssetBundleBase, AssetFileInfo CoverTextureInfo, AssetFileInfo CoverSpriteInfo)
-        InitializeBundle(ConversionContext context)
+        InitializeBundle(string templatePath, string codename)
     {
-        string coverPackagePath = context.FileSystem.TemplateFiles.Cover;
         AssetsManager manager = new();
-        BundleFileInstance bunInst = manager.LoadBundleFile(coverPackagePath, true);
+        BundleFileInstance bunInst = manager.LoadBundleFile(templatePath, true);
         AssetsFileInstance afileInst = manager.LoadAssetsFileFromBundle(bunInst, 0, false);
         AssetsFile afile = afileInst.file;
         afile.GenerateQuickLookup();
@@ -72,9 +109,8 @@ public static class CoverBundleGenerator
         AssetFileInfo assetBundleInfo = sortedAssetInfos.First(x => x.TypeId == (int)AssetClassID.AssetBundle);
         AssetTypeValueField assetBundleBase = manager.GetBaseField(afileInst, assetBundleInfo);
 
-        assetBundleBase["m_Name"].AsString = $"{context.SongData.Name}_Cover";
-        assetBundleBase["m_AssetBundleName"].AsString = $"{context.SongData.Name}_Cover";
-        // AssetTypeValueField assetBundleArray = assetBundleBase["m_PreloadTable"]["Array"]; // Not directly modified here but good to be aware of
+        assetBundleBase["m_Name"].AsString = $"{codename}_Cover";
+        assetBundleBase["m_AssetBundleName"].AsString = $"{codename}_Cover";
 
         AssetFileInfo coverTextureInfo = sortedAssetInfos.First(x => x.TypeId == (int)AssetClassID.Texture2D);
         AssetFileInfo coverSpriteInfo = sortedAssetInfos.First(x => x.TypeId == (int)AssetClassID.Sprite);
@@ -90,21 +126,27 @@ public static class CoverBundleGenerator
         coverImage ??= CoverArtGenerator.ExistingCover(context);
         coverImage ??= CoverArtGenerator.GenerateOwnCover(context);
 
-        if (coverImage != null)
+        if (coverImage == null)
         {
-            // Save the image in the temp folder
-            string tempCoverPath = Path.Combine(context.FileSystem.TempFolders.MenuArtFolder, $"Cover_{context.SongData.Name}.png");
-            coverImage.Save(tempCoverPath);
-            Logger.Log($"Cover image prepared and saved to: {tempCoverPath}", LogLevel.Debug);
+            Logger.Log("No cover image could be prepared.", LogLevel.Warning);
+            return null;
         }
+
+        // Save the image in the temp folder
+        string tempCoverPath = Path.Combine(context.FileSystem.TempFolders.MenuArtFolder, $"Cover_{context.SongData.Name}.png");
+        coverImage.Mutate(x => x.Resize(640, 360));
+        coverImage.Save(tempCoverPath);
+        Logger.Log($"Cover image prepared and saved to: {tempCoverPath}", LogLevel.Debug);
+
+        // Resize the image to 640x360
 
         return coverImage;
     }
 
-    private static void UpdateCoverTexture(ConversionContext context, AssetsManager manager, AssetsFileInstance afileInst, AssetFileInfo coverInfo, Image<Rgba32> coverImage)
+    private static void UpdateCoverTexture(string codename, AssetsManager manager, AssetsFileInstance afileInst, AssetFileInfo coverInfo, Image<Rgba32> coverImage)
     {
         AssetTypeValueField coverBase = manager.GetBaseField(afileInst, coverInfo);
-        coverBase["m_Name"].AsString = $"{context.SongData.Name}_Cover_2x";
+        coverBase["m_Name"].AsString = $"{codename}_Cover_2x";
 
         TextureFormat fmt = TextureFormat.DXT1Crunched;
         int mips = 1;
@@ -119,20 +161,19 @@ public static class CoverBundleGenerator
         coverInfo.SetNewData(coverBase);
     }
 
-    private static void UpdateCoverSprite(ConversionContext context, AssetsManager manager, AssetsFileInstance afileInst, AssetFileInfo coverSpriteInfo)
+    private static void UpdateCoverSprite(string codename, AssetsManager manager, AssetsFileInstance afileInst, AssetFileInfo coverSpriteInfo)
     {
         AssetTypeValueField coverSpriteBase = manager.GetBaseField(afileInst, coverSpriteInfo);
-        coverSpriteBase["m_Name"].AsString = $"{context.SongData.Name}_Cover_2x";
+        coverSpriteBase["m_Name"].AsString = $"{codename}_Cover_2x";
         // Potentially other sprite properties might need updates if they depend on texture size or content,
         // but usually for covers, only the name and the texture link (implicit via AssetBundle structure) change.
         coverSpriteInfo.SetNewData(coverSpriteBase);
     }
 
-    private static void FinalizeAndSaveBundle(ConversionContext context, AssetBundleFile bun, AssetsFile afile, AssetTypeValueField assetBundleBase, Action<AssetTypeValueField> setAssetBundleData)
+    private static void FinalizeAndSaveBundle(string outputFolderPath, bool forCustomServer, AssetBundleFile bun, AssetsFile afile, AssetTypeValueField assetBundleBase, Action<AssetTypeValueField> setAssetBundleData)
     {
         setAssetBundleData(assetBundleBase);
         bun.BlockAndDirInfo.DirectoryInfos[0].SetNewData(afile);
-        string outputPackagePath = context.FileSystem.OutputFolders.CoverFolder;
-        bun.SaveAndCompress(outputPackagePath, context.Request.ExportType == ExportType.CustomServer);
+        bun.SaveAndCompress(outputFolderPath, forCustomServer);
     }
 }

--- a/JustDanceEditor.Converter/Converters/Bundles/SongTitleLogoBundleGenerator.cs
+++ b/JustDanceEditor.Converter/Converters/Bundles/SongTitleLogoBundleGenerator.cs
@@ -34,6 +34,42 @@ public static class SongTitleBundleGenerator
         Logger.Log("Finished generating song title logo");
     }
 
+    /// <summary>
+    /// Generates a song title logo bundle from a user-provided image path, bypassing the full conversion context.
+    /// </summary>
+    /// <param name="codename">The codename of the song.</param>
+    /// <param name="imagePath">The path to the song title logo image.</param>
+    /// <param name="templatePath">The path to the template song title logo bundle file.</param>
+    /// <param name="outputFolderPath">The folder where the generated bundle will be saved.</param>
+    /// <param name="forCustomServer">Whether to format the bundle for a custom server.</param>
+    public static void GenerateSongTitleLogo(string codename, Image<Rgba32> titleImage, string templatePath, string outputFolderPath, bool forCustomServer)
+    {
+        try
+        {
+            Logger.Log($"Starting trivial generation for song title logo: {codename}");
+
+            // Initialize AssetsManager and load bundle data
+            var (Manager, BunInst, AFileInst, AFile, AssetBundleInfo, AssetBundleBase, TextureInfo, SpriteInfo) =
+                InitializeBundle(templatePath, codename);
+
+            // Process the image (resize, pad) and update the texture asset
+            UpdateSongTitleTexture(codename, Manager, AFileInst, TextureInfo, titleImage);
+
+            // Update the sprite asset associated with the song title
+            UpdateSongTitleSprite(codename, Manager, AFileInst, SpriteInfo);
+
+            // Apply all changes to the AssetBundle and save the modified bundle file
+            FinalizeAndSaveBundle(outputFolderPath, forCustomServer, BunInst.file, AFile, AssetBundleBase, AssetBundleInfo.SetNewData);
+
+            Logger.Log($"Finished generating trivial song title logo for {codename}");
+        }
+        catch (Exception e)
+        {
+            Logger.Log($"Failed to generate trivial song title logo for {codename}: {e.Message}", LogLevel.Error);
+            throw;
+        }
+    }
+
     private static void GenerateSongTitleLogoInternal(ConversionContext context)
     {
         // Attempt to load or find the song title image
@@ -45,17 +81,15 @@ public static class SongTitleBundleGenerator
         }
 
         Logger.Log("Converting SongTitleLogo...");
-        // Initialize AssetsManager and load bundle data
-        var (Manager, BunInst, AFileInst, AFile, AssetBundleInfo, AssetBundleBase, TextureInfo, SpriteInfo) = InitializeBundle(context);
 
-        // Process the image (resize, pad) and update the texture asset
-        UpdateSongTitleTexture(context, Manager, AFileInst, TextureInfo, titleImage);
-
-        // Update the sprite asset associated with the song title
-        UpdateSongTitleSprite(context, Manager, AFileInst, SpriteInfo);
-
-        // Apply all changes to the AssetBundle and save the modified bundle file
-        FinalizeAndSaveBundle(context, BunInst.file, AFile, AssetBundleBase, AssetBundleInfo.SetNewData);
+        // Call the original GenerateSongTitleLogo function
+        GenerateSongTitleLogo(
+            context.SongData.Name,
+            titleImage,
+            context.FileSystem.TemplateFiles.SongTitleLogo,
+            context.FileSystem.OutputFolders.SongTitleLogoFolder,
+            context.Request.ExportType == ExportType.CustomServer
+        );
     }
 
     private static Image<Rgba32>? PrepareSongTitleImage(ConversionContext context)
@@ -70,11 +104,10 @@ public static class SongTitleBundleGenerator
     }
 
     private static (AssetsManager Manager, BundleFileInstance BunInst, AssetsFileInstance AFileInst, AssetsFile AFile, AssetFileInfo AssetBundleInfo, AssetTypeValueField AssetBundleBase, AssetFileInfo TextureInfo, AssetFileInfo SpriteInfo)
-        InitializeBundle(ConversionContext context)
+    InitializeBundle(string templatePath, string codename)
     {
-        string songTitleLogoPackagePath = context.FileSystem.TemplateFiles.SongTitleLogo;
         AssetsManager manager = new();
-        BundleFileInstance bunInst = manager.LoadBundleFile(songTitleLogoPackagePath, true);
+        BundleFileInstance bunInst = manager.LoadBundleFile(templatePath, true);
         AssetsFileInstance afileInst = manager.LoadAssetsFileFromBundle(bunInst, 0, false);
         AssetsFile afile = afileInst.file;
         afile.GenerateQuickLookup();
@@ -83,8 +116,8 @@ public static class SongTitleBundleGenerator
         AssetFileInfo assetBundleInfo = sortedAssetInfos.First(x => x.TypeId == (int)AssetClassID.AssetBundle);
         AssetTypeValueField assetBundleBase = manager.GetBaseField(afileInst, assetBundleInfo);
 
-        assetBundleBase["m_Name"].AsString = $"{context.SongData.Name}_SongTitleLogo";
-        assetBundleBase["m_AssetBundleName"].AsString = $"{context.SongData.Name}_SongTitleLogo";
+        assetBundleBase["m_Name"].AsString = $"{codename}_SongTitleLogo";
+        assetBundleBase["m_AssetBundleName"].AsString = $"{codename}_SongTitleLogo";
 
         AssetFileInfo textureInfo = sortedAssetInfos.First(x => x.TypeId == (int)AssetClassID.Texture2D);
         AssetFileInfo spriteInfo = sortedAssetInfos.First(x => x.TypeId == (int)AssetClassID.Sprite);
@@ -92,10 +125,10 @@ public static class SongTitleBundleGenerator
         return (manager, bunInst, afileInst, afile, assetBundleInfo, assetBundleBase, textureInfo, spriteInfo);
     }
 
-    private static void UpdateSongTitleTexture(ConversionContext context, AssetsManager manager, AssetsFileInstance afileInst, AssetFileInfo textureInfo, Image<Rgba32> image)
+    private static void UpdateSongTitleTexture(string codename, AssetsManager manager, AssetsFileInstance afileInst, AssetFileInfo textureInfo, Image<Rgba32> image)
     {
         AssetTypeValueField textureBase = manager.GetBaseField(afileInst, textureInfo);
-        textureBase["m_Name"].AsString = $"{context.SongData.Name}_Title";
+        textureBase["m_Name"].AsString = $"{codename}_Title";
 
         // Ensure 2:1 aspect ratio and 1024x512 size
         if (image.Width / (float)image.Height != 2f)
@@ -119,20 +152,19 @@ public static class SongTitleBundleGenerator
         textureInfo.SetNewData(textureBase);
     }
 
-    private static void UpdateSongTitleSprite(ConversionContext context, AssetsManager manager, AssetsFileInstance afileInst, AssetFileInfo spriteInfo)
+    private static void UpdateSongTitleSprite(string codename, AssetsManager manager, AssetsFileInstance afileInst, AssetFileInfo spriteInfo)
     {
         AssetTypeValueField spriteBase = manager.GetBaseField(afileInst, spriteInfo);
-        spriteBase["m_Name"].AsString = $"{context.SongData.Name}_Title";
+        spriteBase["m_Name"].AsString = $"{codename}_Title";
         // Sprite properties might need adjustment based on new texture dimensions or content (e.g., m_Rect, m_RD.textureRect).
         // Assuming template sprite settings are general enough or handled by implicit texture link.
         spriteInfo.SetNewData(spriteBase);
     }
 
-    private static void FinalizeAndSaveBundle(ConversionContext context, AssetBundleFile bun, AssetsFile afile, AssetTypeValueField assetBundleBase, Action<AssetTypeValueField> setAssetBundleData)
+    private static void FinalizeAndSaveBundle(string outputFolderPath, bool keepExtension, AssetBundleFile bun, AssetsFile afile, AssetTypeValueField assetBundleBase, Action<AssetTypeValueField> setAssetBundleData)
     {
         setAssetBundleData(assetBundleBase);
         bun.BlockAndDirInfo.DirectoryInfos[0].SetNewData(afile);
-        string outputPackagePath = context.FileSystem.OutputFolders.SongTitleLogoFolder;
-        bun.SaveAndCompress(outputPackagePath, context.Request.ExportType == ExportType.CustomServer);
+        bun.SaveAndCompress(outputFolderPath, keepExtension);
     }
 }

--- a/JustDanceEditor.UI/Converting/ConverterDialogue.cs
+++ b/JustDanceEditor.UI/Converting/ConverterDialogue.cs
@@ -1,10 +1,16 @@
 ﻿using JustDanceEditor.Converter;
 using JustDanceEditor.Converter.Converters;
+using JustDanceEditor.Converter.Converters.Bundles;
 using JustDanceEditor.Converter.Unity;
 using JustDanceEditor.Logging;
 using JustDanceEditor.UI.Helpers;
 
+using SixLabors.ImageSharp;
+using SixLabors.ImageSharp.PixelFormats;
+
 using System.Text.Json;
+
+using TextureConverter.TextureConverterHelpers;
 
 namespace JustDanceEditor.UI.Converting;
 
@@ -72,6 +78,67 @@ public class ConverterDialogue
             Console.WriteLine($"\nAn error occurred during advanced conversion: {e.Message}");
             Console.ResetColor();
             Logger.Log($"Advanced conversion failed: {e.Message}", LogLevel.Fatal);
+        }
+    }
+
+    // Currently requires user to provide both images, would be nice to use the online database to fetch all missing one in a loop?
+    public static void GenerateTrivialBundles()
+    {
+        try
+        {
+            if (!CheckTemplate())
+                return;
+
+            Console.WriteLine("This tool will generate a cover bundle and, optionally, a song title logo bundle from images.");
+
+            Console.WriteLine("Please enter the codename for the song (e.g., 'MySong'):");
+            string codename = Console.ReadLine() ?? "";
+            while (string.IsNullOrWhiteSpace(codename))
+            {
+                Console.ForegroundColor = ConsoleColor.Red;
+                Console.WriteLine("Codename cannot be empty. Please enter a codename:");
+                Console.ResetColor();
+                codename = Console.ReadLine() ?? "";
+            }
+
+            string coverImagePath = Question.AskFile("Please enter the full path to the cover image file", true);
+            string titleLogoImagePath = Question.AskFile("Please enter the full path to the song title logo image file (leave empty to skip)", false);
+            string outputFolder = AskOutputFolder();
+
+            // Generate Cover
+            string templateCoverPath = Directory.GetFiles(Path.Combine("./Template", "Cover"))[0];
+            string outputCoverFolder = Path.Combine(outputFolder, codename, "Cover");
+            using Image<Rgba32> coverImage = TextureImportExport.TryLoadImage(coverImagePath) ?? throw new FileNotFoundException("Cover image could not be loaded.");
+            Console.WriteLine($"\nGenerating cover bundle for '{codename}'...");
+            CoverBundleGenerator.GenerateCover(codename, coverImage, templateCoverPath, outputCoverFolder, true);
+            Console.WriteLine("Cover bundle generated.");
+
+            // Generate SongTitleLogo if path is provided
+            if (!string.IsNullOrWhiteSpace(titleLogoImagePath))
+            {
+                string templateLogoPath = Directory.GetFiles(Path.Combine("./Template", "SongTitleLogo"))[0];
+                string outputLogoFolder = Path.Combine(outputFolder, codename, "songTitleLogo");
+                using Image<Rgba32> titleLogoImage = TextureImportExport.TryLoadImage(titleLogoImagePath) ?? throw new FileNotFoundException("Song title logo image could not be loaded.");
+
+                Console.WriteLine($"\nGenerating song title logo bundle for '{codename}'...");
+                SongTitleBundleGenerator.GenerateSongTitleLogo(codename, titleLogoImage, templateLogoPath, outputLogoFolder, true);
+                Console.WriteLine("Song title logo bundle generated.");
+            }
+            else
+            {
+                Console.WriteLine("\nSkipping song title logo bundle generation as no path was provided.");
+            }
+
+            Console.ForegroundColor = ConsoleColor.Green;
+            Console.WriteLine("\nBundle generation completed successfully!");
+            Console.ResetColor();
+        }
+        catch (Exception e)
+        {
+            Console.ForegroundColor = ConsoleColor.Red;
+            Console.WriteLine($"\nAn error occurred during bundle generation: {e.Message}");
+            Console.ResetColor();
+            Logger.Log($"Trivial bundle generation failed: {e.Message}", LogLevel.Fatal);
         }
     }
 

--- a/JustDanceEditor.UI/Program.cs
+++ b/JustDanceEditor.UI/Program.cs
@@ -45,6 +45,7 @@ internal class Program
                 "Convert UbiArt Map to Unity (Standard)",
                 "Convert UbiArt Map to Unity (Advanced Options)",
                 "Batch Convert All Songs in a Folder",
+                "Trivially Generate Cover and SongTitleLogo Bundles",
                 "Extract IPK Archive File",
                 "Generate a New Cache Structure",
                 "Optimize Cache Folders for exFAT (Spread Caches equally)"
@@ -69,14 +70,18 @@ internal class Program
                     ConverterDialogue.ConvertAllSongsInFolder();
                     break;
                 case 4:
+                    Console.WriteLine("--- Trivial Bundle Generation ---");
+                    ConverterDialogue.GenerateTrivialBundles();
+                    break;
+                case 5:
                     Console.WriteLine("--- Extract IPK Archive ---");
                     ExtractorDialogue.ExtractDialogue();
                     break;
-                case 5:
+                case 6:
                     Console.WriteLine("--- Generate New Cache ---");
                     CacheDialogue.GenerateCacheDialogue();
                     break;
-                case 6:
+                case 7:
                     Console.WriteLine("--- Spread Cache for exFAT ---");
                     CacheDialogue.SpreadCacheDialogue();
                     break;

--- a/TextureConverter/TextureConverterHelpers/TextureImportExport.cs
+++ b/TextureConverter/TextureConverterHelpers/TextureImportExport.cs
@@ -6,6 +6,19 @@ namespace TextureConverter.TextureConverterHelpers;
 
 public class TextureImportExport
 {
+    public static Image<Rgba32>? TryLoadImage(string path)
+    {
+        try
+        {
+            Image<Rgba32> image = Image.Load<Rgba32>(path);
+            return image;
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
     public static byte[] Import(
         Image<Rgba32> image, TextureFormat format,
         out int width, out int height, ref int mips)


### PR DESCRIPTION
Add trivial bundle generation for covers and logos

Implemented new methods in `CoverBundleGenerator` and `SongTitleBundleGenerator` to generate cover and song title logo bundles directly from images. Refactored existing methods to simplify the process and updated initialization to accept template paths and codenames. Introduced `GenerateTrivialBundles` in `ConverterDialogue` for user interaction and enhanced the main menu in `Program` to include this feature. Added error handling and integrated `SixLabors.ImageSharp` for image processing tasks.