### PR TITLE
Refactor legacy mashup scheduling and improve file lookup

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -35,7 +35,7 @@
     <KevIncTextureXboxImageSharpProject>$(KevIncTextureRoot)src\KevInc.Texture.Xbox.ImageSharp\KevInc.Texture.Xbox.ImageSharp.csproj</KevIncTextureXboxImageSharpProject>
 
     <KevIncUbiArtRoot Condition="'$(KevIncUbiArtRoot)' == ''">$([MSBuild]::NormalizeDirectory('$(KevIncReposRoot)', 'KevInc.UbiArt'))</KevIncUbiArtRoot>
-    <KevIncUbiArtPackageVersion>0.2.3</KevIncUbiArtPackageVersion>
+    <KevIncUbiArtPackageVersion>0.2.4</KevIncUbiArtPackageVersion>
     <KevIncUbiArtIpkProject>$(KevIncUbiArtRoot)src\KevInc.UbiArt.Ipk\KevInc.UbiArt.Ipk.csproj</KevIncUbiArtIpkProject>
     <KevIncUbiArtFileSystemProject>$(KevIncUbiArtRoot)src\KevInc.UbiArt.FileSystem\KevInc.UbiArt.FileSystem.csproj</KevIncUbiArtFileSystemProject>
     <KevIncUbiArtRakiProject>$(KevIncUbiArtRoot)src\KevInc.UbiArt.Raki\KevInc.UbiArt.Raki.csproj</KevIncUbiArtRakiProject>

--- a/JustDanceEditor.Formats.UbiArt.Tests/MashupDataTests.cs
+++ b/JustDanceEditor.Formats.UbiArt.Tests/MashupDataTests.cs
@@ -123,12 +123,7 @@ public sealed class MashupDataTests
             Path.Combine("world", "jd5", "_mashup", "cinematics"),
             mashup,
             timeline,
-            UbiArtEngineVersion.JD2014,
-            transitionTapeLeadFrames: new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase)
-            {
-                ["coach_move_1.tape"] = 10,
-                ["coach_move_2.tape"] = 10
-            });
+            UbiArtEngineVersion.JD2014);
 
         Assert.Equal(6, visits.Count);
         Assert.EndsWith(Path.Combine("cinematics", "init.tape"), visits[0].Path);
@@ -142,37 +137,37 @@ public sealed class MashupDataTests
         Assert.Equal(168, visits[2].TimeOffsetFrames);
         Assert.Equal(384, visits[2].DurationFrames);
         Assert.EndsWith(Path.Combine("cinematics", "coach_move_1.tape"), visits[3].Path);
-        Assert.Equal(158, visits[3].TimeOffsetFrames);
+        Assert.Equal(144, visits[3].TimeOffsetFrames);
         Assert.Null(visits[3].DurationFrames);
         Assert.EndsWith(Path.Combine("cinematics", "color_blue.tape"), visits[4].Path);
         Assert.Equal(552, visits[4].TimeOffsetFrames);
         Assert.Equal(504, visits[4].DurationFrames);
         Assert.EndsWith(Path.Combine("cinematics", "coach_move_2.tape"), visits[5].Path);
-        Assert.Equal(542, visits[5].TimeOffsetFrames);
+        Assert.Equal(528, visits[5].TimeOffsetFrames);
         Assert.Null(visits[5].DurationFrames);
 
         IReadOnlyList<TapeVisit> fxVisits = MashupTransitionFxScheduler.BuildTransitionFxTapeVisits(
             Path.Combine("world", "jd5", "_mashup", "cinematics"),
             mashup,
             timeline,
-            UbiArtEngineVersion.JD2014,
-            fxTapeLeadFrames: 10);
+            UbiArtEngineVersion.JD2014);
 
         Assert.Equal(4, fxVisits.Count);
         Assert.EndsWith(Path.Combine("cinematics", "fx.tape"), fxVisits[0].Path);
-        Assert.Equal(152, fxVisits[0].TimeOffsetFrames);
+        Assert.Equal(144, fxVisits[0].TimeOffsetFrames);
         Assert.Null(fxVisits[0].DurationFrames);
         Assert.Contains("x_lines_2x5", fxVisits[0].TargetFilter!.IncludeKeyContains);
         Assert.EndsWith(Path.Combine("cinematics", "fx.tape"), fxVisits[1].Path);
-        Assert.Equal(152, fxVisits[1].TimeOffsetFrames);
+        Assert.Equal(144, fxVisits[1].TimeOffsetFrames);
         Assert.Null(fxVisits[1].DurationFrames);
         Assert.Contains("x_lines_2x5", fxVisits[1].TargetFilter!.ExcludeKeyContains);
+        Assert.Contains("x_mashup_godrayscreen", fxVisits[1].TargetFilter.ExcludeKeyContains);
         Assert.EndsWith(Path.Combine("cinematics", "fx.tape"), fxVisits[2].Path);
-        Assert.Equal(536, fxVisits[2].TimeOffsetFrames);
+        Assert.Equal(528, fxVisits[2].TimeOffsetFrames);
         Assert.Null(fxVisits[2].DurationFrames);
         Assert.Contains("x_lines_2x5", fxVisits[2].TargetFilter!.IncludeKeyContains);
         Assert.EndsWith(Path.Combine("cinematics", "fx.tape"), fxVisits[3].Path);
-        Assert.Equal(536, fxVisits[3].TimeOffsetFrames);
+        Assert.Equal(528, fxVisits[3].TimeOffsetFrames);
         Assert.Null(fxVisits[3].DurationFrames);
         Assert.Contains("x_lines_2x5", fxVisits[3].TargetFilter!.ExcludeKeyContains);
     }
@@ -214,18 +209,12 @@ public sealed class MashupDataTests
             Path.Combine("world", "jd5", "_mashup", "cinematics"),
             mashup,
             timeline,
-            UbiArtEngineVersion.JD2014,
-            transitionTapeLeadFrames: new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase)
-            {
-                ["coach_move_1.tape"] = 10,
-                ["coach_move_2.tape"] = 10
-            });
+            UbiArtEngineVersion.JD2014);
         IReadOnlyList<TapeVisit> fxVisits = MashupTransitionFxScheduler.BuildTransitionFxTapeVisits(
             Path.Combine("world", "jd5", "_mashup", "cinematics"),
             mashup,
             timeline,
-            UbiArtEngineVersion.JD2014,
-            fxTapeLeadFrames: 10);
+            UbiArtEngineVersion.JD2014);
 
         int[] coachMoveOffsets =
         [
@@ -233,21 +222,21 @@ public sealed class MashupDataTests
                 .Where(visit => Path.GetFileName(visit.Path).StartsWith("coach_move_", StringComparison.OrdinalIgnoreCase))
                 .Select(visit => visit.TimeOffsetFrames)
         ];
-        Assert.Equal(new[] { 158, 926 }, coachMoveOffsets);
-        Assert.DoesNotContain(visits, visit => visit.TimeOffsetFrames == 542);
+        Assert.Equal(new[] { 144, 912 }, coachMoveOffsets);
+        Assert.DoesNotContain(visits, visit => visit.TimeOffsetFrames == 528);
 
         Assert.Equal(4, fxVisits.Count);
         Assert.EndsWith(Path.Combine("cinematics", "fx.tape"), fxVisits[0].Path);
-        Assert.Equal(152, fxVisits[0].TimeOffsetFrames);
+        Assert.Equal(144, fxVisits[0].TimeOffsetFrames);
         Assert.Null(fxVisits[0].DurationFrames);
         Assert.EndsWith(Path.Combine("cinematics", "fx.tape"), fxVisits[1].Path);
-        Assert.Equal(152, fxVisits[1].TimeOffsetFrames);
+        Assert.Equal(144, fxVisits[1].TimeOffsetFrames);
         Assert.Null(fxVisits[1].DurationFrames);
         Assert.EndsWith(Path.Combine("cinematics", "fx.tape"), fxVisits[2].Path);
-        Assert.Equal(920, fxVisits[2].TimeOffsetFrames);
+        Assert.Equal(912, fxVisits[2].TimeOffsetFrames);
         Assert.Null(fxVisits[2].DurationFrames);
         Assert.EndsWith(Path.Combine("cinematics", "fx.tape"), fxVisits[3].Path);
-        Assert.Equal(920, fxVisits[3].TimeOffsetFrames);
+        Assert.Equal(912, fxVisits[3].TimeOffsetFrames);
         Assert.Null(fxVisits[3].DurationFrames);
     }
 
@@ -282,12 +271,11 @@ public sealed class MashupDataTests
             Path.Combine("world", "jd5", "_mashup", "cinematics"),
             mashup,
             timeline,
-            UbiArtEngineVersion.JD2014,
-            fxTapeLeadFrames: 10);
+            UbiArtEngineVersion.JD2014);
 
         Assert.Equal(2, fxVisits.Count);
-        Assert.Equal(80, fxVisits[0].TimeOffsetFrames);
-        Assert.Equal(80, fxVisits[1].TimeOffsetFrames);
+        Assert.Equal(72, fxVisits[0].TimeOffsetFrames);
+        Assert.Equal(72, fxVisits[1].TimeOffsetFrames);
         Assert.Contains("x_lines_2x5", fxVisits[0].TargetFilter!.IncludeKeyContains);
         Assert.Contains("x_lines_2x5", fxVisits[1].TargetFilter!.ExcludeKeyContains);
     }

--- a/JustDanceEditor.Formats.UbiArt.Tests/MashupTransitionSchedulerTests.cs
+++ b/JustDanceEditor.Formats.UbiArt.Tests/MashupTransitionSchedulerTests.cs
@@ -69,19 +69,19 @@ public sealed class MashupTransitionSchedulerTests
             mashup,
             timeline,
             UbiArtEngineVersion.JD2014,
-            fxTapeDurationFrames: 72,
-            fxTapeLeadFrames: 10);
+            fxTapeDurationFrames: 72);
 
         TapeVisit coachMoveVisit = Assert.Single(
             visits,
             visit => visit.Path.EndsWith("coach_move_1.tape", StringComparison.OrdinalIgnoreCase));
+        Assert.Equal(144, coachMoveVisit.TimeOffsetFrames);
         Assert.Equal(96, coachMoveVisit.DurationFrames);
         Assert.Equal(4, fxVisits.Count);
         Assert.All(fxVisits, visit => Assert.Equal(72, visit.DurationFrames));
-        Assert.Equal(152, fxVisits[0].TimeOffsetFrames);
-        Assert.Equal(152, fxVisits[1].TimeOffsetFrames);
-        Assert.Equal(536, fxVisits[2].TimeOffsetFrames);
-        Assert.Equal(536, fxVisits[3].TimeOffsetFrames);
+        Assert.Equal(144, fxVisits[0].TimeOffsetFrames);
+        Assert.Equal(144, fxVisits[1].TimeOffsetFrames);
+        Assert.Equal(528, fxVisits[2].TimeOffsetFrames);
+        Assert.Equal(528, fxVisits[3].TimeOffsetFrames);
     }
 
     [Fact]

--- a/JustDanceEditor.Formats.UbiArt.Tests/MashupVideoRendererTests.cs
+++ b/JustDanceEditor.Formats.UbiArt.Tests/MashupVideoRendererTests.cs
@@ -203,47 +203,8 @@ public sealed class MashupVideoRendererTests
     }
 
     [Fact]
-    public void MashupCoachRevealDelayUsesGodrayScreenAlphaClipEnd()
+    public void MashupJd2014TransitionLeadMatchesWiiGameplayScheduling()
     {
-        uint alphaTypeId = LegacyBinarySerializer.GetTypeId<CinematicAlphaClipBinary>();
-        TapeClip godrayAlpha = new(
-            alphaTypeId,
-            StartFrame: 10,
-            DurationFrames: 21,
-            Path: null,
-            Targets: [new ActorTargetPath(["_mashup_graph", "fx", "x_speedlines_00", "x_mashup_godrayscreen"])],
-            Curves:
-            [
-                new CinematicCurve(
-                [
-                    new CinematicKeyframe(0, 0, 0, 0, 0, 0),
-                    new CinematicKeyframe(5, 1, 5, 1, 5, 1),
-                    new CinematicKeyframe(21, 0, 21, 0, 21, 0)
-                ])
-            ]);
-
-        Assert.Equal(31, MashupTransitionFxScheduler.GetCoachRevealDelayFrames([godrayAlpha]));
-    }
-
-    [Fact]
-    public void MashupTransitionFxVisitUsesAuthoredFxTapeLeadAtBlockStart()
-    {
-        Assert.Equal(
-            -16,
-            MashupTransitionFxScheduler.GetVisitOffsetFromBlock(
-                fxTapeLeadFrames: 10));
-
-        Assert.Equal(
-            -16,
-            MashupTransitionFxScheduler.GetVisitOffsetFromBlock(
-                fxTapeLeadFrames: 10));
-
-        Assert.Equal(
-            -32,
-            MashupTransitionFxScheduler.GetVisitOffsetFromBlock(
-                fxTapeLeadFrames: 10,
-                fxTapeFlashLeadFrames: 18));
-
-        Assert.Equal(6, MashupTransitionFxScheduler.GetCoachFadeActiveFrames());
+        Assert.Equal(24, MashupTransitionTapeTiming.Jd2014TransitionLeadFrames);
     }
 }

--- a/JustDanceEditor.Formats.UbiArt.Tests/MultipleSongsSelectionTests.cs
+++ b/JustDanceEditor.Formats.UbiArt.Tests/MultipleSongsSelectionTests.cs
@@ -1,5 +1,6 @@
 using JustDanceEditor.Formats.UbiArt.FileSystem;
 using JustDanceEditor.Formats.UbiArt.Import;
+using JustDanceEditor.Formats.UbiArt.Import.Cinematics.Video;
 using JustDanceEditor.Formats.UbiArt.Import.Layouts;
 using JustDanceEditor.Formats.UbiArt.Model;
 using JustDanceEditor.Formats.UbiArt.Serialization.Binary;
@@ -19,6 +20,123 @@ namespace JustDanceEditor.Formats.UbiArt.Tests;
 
 public class MultipleSongsSelectionTests
 {
+    [Theory]
+    [InlineData(UbiArtPlatform.Revolution, "WII")]
+    [InlineData(UbiArtPlatform.Cafe, "WIIU")]
+    [InlineData(UbiArtPlatform.Cell, "PS3")]
+    [InlineData(UbiArtPlatform.Xenon, "X360")]
+    public void GetFilePath_LegacySongInput_ResolvesSiblingBlockFlowsPackage(UbiArtPlatform platform, string platformName)
+    {
+        string root = Path.Combine(Path.GetTempPath(), "jde_test_" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(root);
+        try
+        {
+            string inputBundle = Path.Combine(root, $"Song_{platformName}");
+            string blockFlows = Path.Combine(root, $"BlockFlows_{platformName}");
+            string sourceTimeline = Path.Combine(
+                blockFlows,
+                "cache",
+                "itf_cooked",
+                platform.GetCookedFolderName(),
+                "world",
+                "jdblocks",
+                "source_1",
+                "timeline");
+            Directory.CreateDirectory(inputBundle);
+            Directory.CreateDirectory(sourceTimeline);
+            File.WriteAllText(Path.Combine(sourceTimeline, "source_1_tml_dance.dtape.ckd"), "source timeline");
+            string sourceVideoFolder = Path.Combine(Path.GetDirectoryName(sourceTimeline)!, "videoscoach");
+            Directory.CreateDirectory(sourceVideoFolder);
+            File.WriteAllText(Path.Combine(sourceVideoFolder, $"source_1.{platform.GetCookedFolderName()}.webm"), "source video");
+
+            UbiArtConversionRequest request = new(inputBundle, Path.Combine(root, "out"), null)
+            {
+                Type = CookedType.Cooked
+            };
+            UbiArtVersionProfile profile = new(
+                platform,
+                UbiArtEngineVersion.JD2015,
+                new JD2015LayoutResolver(),
+                new BinaryUbiArtSerializer(UbiArtEngineVersion.JD2015));
+            using JustDanceUbiArtFileSystem fileSystem = new(request, profile, NullLogger<JustDanceUbiArtFileSystem>.Instance);
+            fileSystem.Initialize();
+
+            bool found = fileSystem.GetFilePath(
+                Path.Combine("world", "jdblocks", "source_1", "timeline", "source_1_tml_dance.dtape"),
+                out CookedFile? sourceFile);
+            LegacyMashupData mashup = new() { MapName = "testMU", BaseSongName = "test" };
+            LegacyMashupBlock block = new()
+            {
+                UsesAlternativeBlock = true,
+                SourceBlock = new LegacyMashupBlockDescriptor { SongName = "source_1", FirstBeat = 0, LastBeat = 16 }
+            };
+            bool foundVideo = MashupSourceVideoResolver.TryFindSourceVideo(fileSystem, mashup, block, out MashupSourceVideo sourceVideo);
+
+            Assert.True(found);
+            Assert.NotNull(sourceFile);
+            Assert.True(foundVideo);
+            Assert.EndsWith($"source_1.{platform.GetCookedFolderName()}.webm", sourceVideo.File.RelativePath, StringComparison.OrdinalIgnoreCase);
+        }
+        finally
+        {
+            try
+            {
+                Directory.Delete(root, true);
+            }
+            catch { }
+        }
+    }
+
+    [Fact]
+    public void GetAvailableSongs_DoesNotTreatEmptyLegacyMashupMarkerAsMashup()
+    {
+        string root = Path.Combine(Path.GetTempPath(), "jde_test_" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(root);
+        try
+        {
+            string inputBundle = Path.Combine(root, "Bundle_4_WII");
+            string songFolder = Path.Combine(
+                inputBundle,
+                "cache",
+                "itf_cooked",
+                "wii",
+                "world",
+                "jd2015",
+                "happyalt");
+            string timelineFolder = Path.Combine(songFolder, "timeline");
+            Directory.CreateDirectory(timelineFolder);
+            File.WriteAllText(Path.Combine(songFolder, "songdesc.tpl.ckd"), "song desc");
+            File.WriteAllBytes(
+                Path.Combine(timelineFolder, "happyaltmu.tpl.ckd"),
+                Convert.FromHexString(
+                    "00000001000000981B857BCE0000006C00000000000000000000000000000000000000000000000000000000000000015B648E4400000028000000010000000000000000"));
+
+            UbiArtConversionRequest request = new(inputBundle, Path.Combine(root, "out"), null)
+            {
+                Type = CookedType.Cooked
+            };
+            UbiArtVersionProfile profile = new(
+                UbiArtPlatform.Revolution,
+                UbiArtEngineVersion.JD2015,
+                new JD2015LayoutResolver(),
+                new BinaryUbiArtSerializer(UbiArtEngineVersion.JD2015));
+            using JustDanceUbiArtFileSystem fileSystem = new(request, profile, NullLogger<JustDanceUbiArtFileSystem>.Instance);
+            fileSystem.Initialize();
+
+            (string SongName, string SongDescPath)[] songs = fileSystem.GetAvailableSongs();
+
+            Assert.Equal(["happyalt"], songs.Select(song => song.SongName));
+        }
+        finally
+        {
+            try
+            {
+                Directory.Delete(root, true);
+            }
+            catch { }
+        }
+    }
+
     [Fact]
     public void GetFilePath_NumberedLegacyBundle_ResolvesSharedSiblingBundleScene()
     {

--- a/JustDanceEditor.Formats.UbiArt/FileSystem/JustDanceUbiArtFileSystem.cs
+++ b/JustDanceEditor.Formats.UbiArt/FileSystem/JustDanceUbiArtFileSystem.cs
@@ -1,6 +1,8 @@
 using JustDanceEditor.Formats.JDI.Services;
 using JustDanceEditor.Formats.UbiArt.Import;
 using JustDanceEditor.Formats.UbiArt.Import.Assets;
+using JustDanceEditor.Formats.UbiArt.Serialization.Binary;
+using JustDanceEditor.Formats.UbiArt.Serialization.Legacy;
 
 using KevInc.UbiArt.FileSystem;
 
@@ -207,6 +209,39 @@ public class JustDanceUbiArtFileSystem : IDisposable
     {
         templatePath = null;
 
+        if (VersionProfile.EngineVersion is not (UbiArtEngineVersion.JD2014 or UbiArtEngineVersion.JD2015) ||
+            VersionProfile.Serializer is not BinaryUbiArtSerializer ||
+            !TryGetLegacyMashupTemplateCandidatePath(songName, out CookedFile? candidate))
+        {
+            return false;
+        }
+
+        try
+        {
+            using Stream stream = GetFileStream(candidate);
+            LegacyBlockFlow blockFlow = VersionProfile.Serializer.Deserialize<LegacyBlockFlow>(stream);
+            if (blockFlow.ComponentCount == 0 ||
+                blockFlow.Component is null ||
+                blockFlow.Component.IsMashUp == 0 ||
+                blockFlow.Component.BlockDescriptorVector.Length == 0)
+            {
+                return false;
+            }
+
+            templatePath = candidate;
+            return true;
+        }
+        catch (Exception ex) when (ex is InvalidDataException or EndOfStreamException or IOException or NotSupportedException)
+        {
+            _logger.LogDebug(ex, "Ignoring invalid legacy mashup template '{TemplatePath}'.", candidate.RelativePath);
+            return false;
+        }
+    }
+
+    private bool TryGetLegacyMashupTemplateCandidatePath(string songName, [MaybeNullWhen(false)] out CookedFile templatePath)
+    {
+        templatePath = null;
+
         if (!TryGetLegacyMashupBaseSongName(songName, out string? baseSongName))
             return false;
 
@@ -289,6 +324,8 @@ public class JustDanceUbiArtFileSystem : IDisposable
         List<string> roots = [];
         AddPackageSearchRoot(roots, io, packageParent, $"Bundle_{upperPlatformName}");
         AddPackageSearchRoot(roots, io, packageParent, $"bundle_{platformName}");
+        AddPackageSearchRoot(roots, io, packageParent, $"BlockFlows_{upperPlatformName}");
+        AddPackageSearchRoot(roots, io, packageParent, $"blockflows_{platformName}");
         AddPackageSearchRoot(roots, io, packageParent, $"patch_{upperPlatformName}");
         AddPackageSearchRoot(roots, io, packageParent, $"Patch_{upperPlatformName}");
         return

--- a/JustDanceEditor.Formats.UbiArt/Import/Cinematics/Video/MashupSourceVideoResolver.cs
+++ b/JustDanceEditor.Formats.UbiArt/Import/Cinematics/Video/MashupSourceVideoResolver.cs
@@ -124,12 +124,15 @@ internal static class MashupSourceVideoResolver
         JustDanceUbiArtFileSystem fileSystem,
         LegacyMashupBlockDescriptor source)
     {
+        string platformName = fileSystem.VersionProfile.Platform.GetCookedFolderName();
         if (fileSystem.VersionProfile.EngineVersion == UbiArtEngineVersion.JD2014 &&
             source.DatabaseGameId is { } databaseGameId)
         {
+            yield return Path.Combine("world", "database", $"jd{databaseGameId}", source.SongName, "videoscoach", $"{source.SongName}.{platformName}.webm");
             yield return Path.Combine("world", "database", $"jd{databaseGameId}", source.SongName, "videoscoach", $"{source.SongName}.webm");
         }
 
+        yield return Path.Combine("world", "jdblocks", source.SongName, "videoscoach", $"{source.SongName}.{platformName}.webm");
         yield return Path.Combine("world", "jdblocks", source.SongName, "videoscoach", $"{source.SongName}.webm");
     }
 
@@ -150,9 +153,12 @@ internal static class MashupSourceVideoResolver
             fileSystem.VersionProfile.Platform,
             fileSystem.VersionProfile.EngineVersion)
             ?? Path.Combine(mapWorldFolder, "media");
+        string platformName = fileSystem.VersionProfile.Platform.GetCookedFolderName();
 
         yield return Path.Combine(mapWorldFolder, "videoscoach", $"{songName}_alpha.webm");
+        yield return Path.Combine(mapWorldFolder, "videoscoach", $"{songName}.{platformName}.webm");
         yield return Path.Combine(mapWorldFolder, "videoscoach", $"{songName}.webm");
+        yield return Path.Combine(mediaFolder, $"{songName}.{platformName}.webm");
         yield return Path.Combine(mediaFolder, $"{songName}.webm");
     }
 

--- a/JustDanceEditor.Formats.UbiArt/Import/Cinematics/Video/MashupTransitionFxScheduler.cs
+++ b/JustDanceEditor.Formats.UbiArt/Import/Cinematics/Video/MashupTransitionFxScheduler.cs
@@ -15,19 +15,14 @@ namespace JustDanceEditor.Formats.UbiArt.Import.Cinematics.Video;
 
 internal static class MashupTransitionFxScheduler
 {
-    // The active fade window starts after the delay and lasts for the remaining duration.
-    private const double MashupVideoFadeBrickDurationBeats = 1.0;
-    private const double MashupVideoFadeOffsetBeats = 0.75;
-    private const double MashupVideoFadeActiveBeats = MashupVideoFadeBrickDurationBeats - MashupVideoFadeOffsetBeats;
-    private const int FlashFxEmitterLeadFrames = 8;
     private const string LineActorKeyMarker = "x_lines_2x5";
-    private const string FlashActorKeyMarker = "x_flashcoach";
+    private const string FullScreenGodrayActorKeyMarker = "x_mashup_godrayscreen";
     private static readonly TapeVisitTargetFilter LineFxFilter = new(
         IncludeKeyContains: [LineActorKeyMarker],
         ExcludeKeyContains: []);
     private static readonly TapeVisitTargetFilter LateFxFilter = new(
         IncludeKeyContains: [],
-        ExcludeKeyContains: [LineActorKeyMarker]);
+        ExcludeKeyContains: [LineActorKeyMarker, FullScreenGodrayActorKeyMarker]);
 
     internal static IReadOnlyList<TapeClip> ReadTransitionFxTapeClips(
         JustDanceUbiArtFileSystem fileSystem,
@@ -54,16 +49,12 @@ internal static class MashupTransitionFxScheduler
             fileSystem,
             logger ?? NullLogger.Instance);
         int fxTapeDurationFrames = MashupTransitionTapeTiming.GetLocalDurationFrames(localFxClips);
-        int fxTapeLeadFrames = MashupTransitionTapeTiming.GetLocalLeadFrames(localFxClips);
-        int fxTapeFlashLeadFrames = MashupTransitionTapeTiming.GetLocalLeadFrames(localFxClips, TargetsTransitionFlashFx);
         return BuildTransitionFxTapeVisits(
             Path.Combine(fileSystem.InputFolders.MapWorldFolder, "cinematics"),
             mashup,
             timelineStructure,
             fileSystem.VersionProfile.EngineVersion,
-            fxTapeDurationFrames > 0 ? fxTapeDurationFrames : null,
-            fxTapeLeadFrames,
-            fxTapeFlashLeadFrames);
+            fxTapeDurationFrames > 0 ? fxTapeDurationFrames : null);
     }
 
     internal static IReadOnlyList<TapeVisit> BuildTransitionFxTapeVisits(
@@ -71,9 +62,7 @@ internal static class MashupTransitionFxScheduler
         LegacyMashupData mashup,
         TimelineStructureDocument timelineStructure,
         UbiArtEngineVersion engineVersion = UbiArtEngineVersion.JD2014,
-        int? fxTapeDurationFrames = null,
-        int fxTapeLeadFrames = 0,
-        int fxTapeFlashLeadFrames = 0)
+        int? fxTapeDurationFrames = null)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(cinematicsFolder);
         ArgumentNullException.ThrowIfNull(mashup);
@@ -86,55 +75,16 @@ internal static class MashupTransitionFxScheduler
         string fxTapePath = Path.Combine(cinematicsFolder, "fx.tape");
         foreach (LegacyMashupBlock block in MashupSegmentBuilder.BuildTransitionBlocks(mashup))
         {
-            int visitOffsetFromBlock = GetVisitOffsetFromBlock(
-                fxTapeLeadFrames,
-                fxTapeFlashLeadFrames);
             AddVisitPair(
                 visits,
                 fxTapePath,
-                MashupTiming.GetLocalTapeFrame(timelineStructure, block.AbsoluteStartBeat) + visitOffsetFromBlock,
+                MashupTiming.GetLocalTapeFrame(timelineStructure, block.AbsoluteStartBeat) -
+                    MashupTransitionTapeTiming.Jd2014TransitionLeadFrames,
                 fxTapeDurationFrames);
         }
 
         return visits;
     }
-
-    internal static int GetCoachRevealDelayFrames(IReadOnlyList<TapeClip> localFxClips)
-    {
-        ArgumentNullException.ThrowIfNull(localFxClips);
-
-        uint alphaTypeId = LegacyBinarySerializer.GetTypeId<CinematicAlphaClipBinary>();
-        double revealFrame = double.NaN;
-        foreach (TapeClip clip in localFxClips)
-        {
-            if (clip.TypeId != alphaTypeId ||
-                clip.DurationFrames <= 0 ||
-                !clip.Targets.Any(target => target.Key.Contains("x_mashup_godrayscreen", StringComparison.OrdinalIgnoreCase)))
-            {
-                continue;
-            }
-
-            double candidate = clip.StartFrame + Math.Max(0, clip.DurationFrames);
-            if (!double.IsFinite(revealFrame) || candidate < revealFrame)
-                revealFrame = candidate;
-        }
-
-        return double.IsFinite(revealFrame) && revealFrame > 0.0
-            ? Math.Max(0, (int)Math.Round(revealFrame))
-            : 0;
-    }
-
-    internal static int GetVisitOffsetFromBlock(
-        int fxTapeLeadFrames,
-        int fxTapeFlashLeadFrames = 0)
-    {
-        int anchorLeadFrames = fxTapeFlashLeadFrames > 0 ? fxTapeFlashLeadFrames : fxTapeLeadFrames;
-        int emitterLeadFrames = fxTapeFlashLeadFrames > 0 ? FlashFxEmitterLeadFrames : 0;
-        return -Math.Max(0, anchorLeadFrames) - GetCoachFadeActiveFrames() - emitterLeadFrames;
-    }
-
-    internal static int GetCoachFadeActiveFrames() =>
-        Math.Max(1, (int)Math.Round(MashupVideoFadeActiveBeats * CinematicConstants.TapeFramesPerBeat));
 
     internal static IReadOnlySet<string> BuildTransitionFxActorKeys(IReadOnlyList<TapeClip> localFxClips)
     {
@@ -189,7 +139,4 @@ internal static class MashupTransitionFxScheduler
             fxTapeDurationFrames,
             TargetFilter: LateFxFilter));
     }
-
-    private static bool TargetsTransitionFlashFx(TapeClip clip) =>
-        clip.Targets.Any(target => target.Key.Contains(FlashActorKeyMarker, StringComparison.OrdinalIgnoreCase));
 }

--- a/JustDanceEditor.Formats.UbiArt/Import/Cinematics/Video/MashupTransitionTapeScheduler.cs
+++ b/JustDanceEditor.Formats.UbiArt/Import/Cinematics/Video/MashupTransitionTapeScheduler.cs
@@ -41,7 +41,8 @@ internal static class MashupTransitionTapeScheduler
         MashupTransitionTapeTimingData timing = MashupTransitionTapeTiming.Build(fileSystem, mashup, resolvedLogger);
         MashupTransitionColorTapeSequence colorTapeSequence = MashupTransitionTapeDiscovery.ResolveColorTapeSequence(
             fileSystem,
-            resolvedLogger);
+            resolvedLogger,
+            mashup.MapName);
         IReadOnlyList<string> uvScrollTapeNames = MashupTransitionTapeDiscovery.ResolveUvScrollTapeSequence(
             fileSystem,
             resolvedLogger);
@@ -135,7 +136,7 @@ internal static class MashupTransitionTapeScheduler
             {
                 int coachMoveIndex = (transitionIndex % 18) + 1;
                 string coachMoveTape = $"coach_move_{coachMoveIndex}.tape";
-                int transitionStartFrames = timeOffsetFrames - MashupTransitionTapeTiming.GetLead(transitionTapeLeadFrames, coachMoveTape);
+                int transitionStartFrames = timeOffsetFrames - MashupTransitionTapeTiming.Jd2014TransitionLeadFrames;
                 visits.Add(new TapeVisit(
                     Path.Combine(cinematicsFolder, coachMoveTape),
                     transitionStartFrames,

--- a/JustDanceEditor.Formats.UbiArt/Import/Cinematics/Video/MashupTransitionTapeScheduler.cs
+++ b/JustDanceEditor.Formats.UbiArt/Import/Cinematics/Video/MashupTransitionTapeScheduler.cs
@@ -41,8 +41,7 @@ internal static class MashupTransitionTapeScheduler
         MashupTransitionTapeTimingData timing = MashupTransitionTapeTiming.Build(fileSystem, mashup, resolvedLogger);
         MashupTransitionColorTapeSequence colorTapeSequence = MashupTransitionTapeDiscovery.ResolveColorTapeSequence(
             fileSystem,
-            resolvedLogger,
-            mashup.MapName);
+            resolvedLogger);
         IReadOnlyList<string> uvScrollTapeNames = MashupTransitionTapeDiscovery.ResolveUvScrollTapeSequence(
             fileSystem,
             resolvedLogger);

--- a/JustDanceEditor.Formats.UbiArt/Import/Cinematics/Video/MashupTransitionTapeTiming.cs
+++ b/JustDanceEditor.Formats.UbiArt/Import/Cinematics/Video/MashupTransitionTapeTiming.cs
@@ -2,6 +2,7 @@ using JustDanceEditor.Formats.UbiArt.FileSystem;
 using JustDanceEditor.Formats.UbiArt.Import.Cinematics.Timeline;
 using JustDanceEditor.Formats.UbiArt.Model;
 
+using KevInc.UbiArt.Cinematics.Core;
 using KevInc.UbiArt.Cinematics.Timeline;
 
 using Microsoft.Extensions.Logging;
@@ -14,6 +15,9 @@ internal sealed record MashupTransitionTapeTimingData(
 
 internal static class MashupTransitionTapeTiming
 {
+    internal static int Jd2014TransitionLeadFrames { get; } =
+        (int)Math.Round(CinematicConstants.TapeFramesPerBeat);
+
     internal static MashupTransitionTapeTimingData Build(
         JustDanceUbiArtFileSystem fileSystem,
         LegacyMashupData mashup,

--- a/JustDanceEditor.Formats.UbiArt/Import/Intermediate/IntermediatePackageBuilder.cs
+++ b/JustDanceEditor.Formats.UbiArt/Import/Intermediate/IntermediatePackageBuilder.cs
@@ -76,7 +76,9 @@ internal static class IntermediatePackageBuilder
         {
             SongID = Guid.NewGuid(),
             MapName = info.MapName,
-            ParentMapName = info.MapName,
+            ParentMapName = context.FileSystem.IsLegacyMashupSelection
+                ? context.FileSystem.LegacyMashupBaseSongName ?? info.MapName
+                : info.MapName,
             Title = info.Title,
             Artist = info.Artist,
             Credits = info.Credits,

--- a/JustDanceEditor.Formats.UbiArt/Import/UbiArtSongPreviewProvider.cs
+++ b/JustDanceEditor.Formats.UbiArt/Import/UbiArtSongPreviewProvider.cs
@@ -87,9 +87,16 @@ public sealed class UbiArtSongPreviewProvider(
         InfoComponent info = songDesc.Components.FirstOrDefault()
             ?? throw new InvalidDataException("SongDesc did not contain an InfoComponent.");
 
+        IntermediateMetadata metadata = BuildMetadata(info, profile, _logger);
+        if (fileSystem.IsLegacyMashupSelection)
+        {
+            metadata.MapName = fileSystem.SongName;
+            metadata.ParentMapName = fileSystem.LegacyMashupBaseSongName ?? info.MapName;
+        }
+
         IntermediateSongPackage package = new()
         {
-            Metadata = BuildMetadata(info, profile, _logger)
+            Metadata = metadata
         };
 
         string packageRoot = Path.Combine(request.WorkingRoot, package.Metadata.MapName);


### PR DESCRIPTION
Refactor legacy mashup scheduling and improve file lookup

- Use fixed lead frame value for legacy mashup transitions
- Remove support for per-tape/custom lead frames in transition/FX scheduling
- Update tests to reflect new timing logic and offsets
- Improve legacy mashup template detection and validation
- Enhance file system search to support BlockFlows_* and Bundle_* roots
- Prefer platform-specific video files in mashup source resolution
- Add tests for block flows package resolution and empty mashup markers
- Set correct ParentMapName for legacy mashup selections in metadata and preview