### PR TITLE
improve uncooked support

### DIFF
--- a/JustDanceEditor.Formats.UbiArt.Tests/AssetResolverTests.cs
+++ b/JustDanceEditor.Formats.UbiArt.Tests/AssetResolverTests.cs
@@ -101,6 +101,32 @@ public class AssetResolverTests
     }
 
     [Fact]
+    public void GetCoachTextures_Ignores_Uncooked_Atlas_Metadata()
+    {
+        string root = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+        string menuArtFolder = Path.Combine(root, "world", "maps", "song", "menuart", "textures");
+        Directory.CreateDirectory(menuArtFolder);
+
+        File.WriteAllText(Path.Combine(menuArtFolder, "song_coach_1.atl"), "ATLAS");
+        File.WriteAllText(Path.Combine(menuArtFolder, "song_coach_1.tga"), "TGA");
+        File.WriteAllText(Path.Combine(menuArtFolder, "song_coach_1.tga.tfi"), "TFI");
+        File.WriteAllText(Path.Combine(menuArtFolder, "song_coach_1_phone.png"), "PNG");
+        File.WriteAllText(Path.Combine(menuArtFolder, "song_coach.ignore"), "IGNORE");
+
+        UbiArtVersionProfile profile = new(UbiArtPlatform.Uncooked, UbiArtEngineVersion.JD2021, new UbiArtLayoutResolver(), new LuaUbiArtSerializer());
+        UbiArtConversionRequest req = new(root, Path.GetTempPath(), "song") { Type = CookedType.Uncooked };
+        JustDanceUbiArtFileSystem fs = new(req, profile, NullLogger<JustDanceUbiArtFileSystem>.Instance);
+        fs.Initialize();
+
+        FileSystemAssetResolver resolver = new(fs.VersionProfile.Layout ?? throw new System.InvalidOperationException("Version profile layout was not initialized."), fs);
+        CookedFile file = Assert.Single(resolver.GetCoachTextures());
+
+        Assert.EndsWith("song_coach_1.tga", file.RelativePath, System.StringComparison.OrdinalIgnoreCase);
+
+        Directory.Delete(root, true);
+    }
+
+    [Fact]
     public void VideoSelector_Prefers_ExactSongVideo_OverAlphaVariant()
     {
         CookedFile selected = UbiArtVideoFileSelector.ChoosePreferredVideoFile(

--- a/JustDanceEditor.Formats.UbiArt.Tests/CinematicVideoTimingTests.cs
+++ b/JustDanceEditor.Formats.UbiArt.Tests/CinematicVideoTimingTests.cs
@@ -2,7 +2,6 @@ using JustDanceEditor.Formats.JDI;
 using JustDanceEditor.Formats.JDI.Timelines;
 using JustDanceEditor.Formats.UbiArt.Import.Cinematics.Video;
 using JustDanceEditor.Formats.UbiArt.Import.Intermediate;
-using JustDanceEditor.Formats.UbiArt.Model;
 
 using Xunit;
 
@@ -50,62 +49,6 @@ public sealed class CinematicVideoTimingTests
         int frameCount = CinematicVisualRenderer.GetRenderFrameCount(0.001);
 
         Assert.Equal(1, frameCount);
-    }
-
-    [Fact]
-    public void SongStartTime_UsesVideoStartTimeForPositiveStartBeat()
-    {
-        JDUbiArtSong song = new()
-        {
-            MusicTrack = new MusicTrack
-            {
-                Components =
-                [
-                    new TrackDataHolder
-                    {
-                        TrackData = new TrackData
-                        {
-                            Structure = new Structure
-                            {
-                                StartBeat = 2,
-                                VideoStartTime = -1.132f,
-                                Markers = [0, 27168, 54336]
-                            }
-                        }
-                    }
-                ]
-            }
-        };
-
-        Assert.Equal(1.132f, song.GetSongStartTime(), precision: 6);
-    }
-
-    [Fact]
-    public void SongStartTime_UsesVideoStartTimeForNegativeStartBeat()
-    {
-        JDUbiArtSong song = new()
-        {
-            MusicTrack = new MusicTrack
-            {
-                Components =
-                [
-                    new TrackDataHolder
-                    {
-                        TrackData = new TrackData
-                        {
-                            Structure = new Structure
-                            {
-                                StartBeat = -9,
-                                VideoStartTime = -0.967f,
-                                Markers = [0, 24000, 48000, 72000, 96000, 120000, 144000, 168000, 192000, 210911]
-                            }
-                        }
-                    }
-                ]
-            }
-        };
-
-        Assert.Equal(0.967f, song.GetSongStartTime(), precision: 6);
     }
 
     private static TimelineStructureDocument CreateTimelineStructure() => new()

--- a/JustDanceEditor.Formats.UbiArt.Tests/DocumentWriterTests.cs
+++ b/JustDanceEditor.Formats.UbiArt.Tests/DocumentWriterTests.cs
@@ -1,0 +1,64 @@
+using JustDanceEditor.Formats.UbiArt.Serialization;
+
+using System;
+using System.IO;
+using System.Linq;
+using System.Text.Json;
+using System.Xml.Linq;
+
+using Xunit;
+
+namespace JustDanceEditor.Formats.UbiArt.Tests;
+
+public sealed class DocumentWriterTests
+{
+    [Fact]
+    public void LuaWriter_SerializesObjectsCollectionsExpressionsAndEscapedStrings()
+    {
+        object value = new
+        {
+            Text = "quote \" slash \\ line\nnext",
+            Mode = new LuaExpression("GameMode.Classic"),
+            Values = new[] { 1, 2, 3 },
+            Empty = Array.Empty<object>()
+        };
+
+        string lua = LuaDocumentWriter.Write(
+            value,
+            includes: ["EngineData/Helpers/SongDatabase.ilu"],
+            trailingStatements: ["afterWrite(params)"]);
+
+        Assert.Contains("includeReference(\"EngineData/Helpers/SongDatabase.ilu\")", lua);
+        Assert.Contains("Text = \"quote \\\" slash \\\\ line\\nnext\"", lua);
+        Assert.Contains("Mode = GameMode.Classic", lua);
+        Assert.Contains("Values =", lua);
+        Assert.Contains("Empty = {}", lua);
+        Assert.EndsWith("afterWrite(params)" + Environment.NewLine, lua, StringComparison.Ordinal);
+
+        JsonElement parsed = LuaTableSerializer.Deserialize<JsonElement>(lua.Replace("afterWrite(params)", ""));
+        Assert.Equal("quote \" slash \\ line\nnext", parsed.GetProperty("Text").GetString());
+    }
+
+    [Fact]
+    public void XmlWriter_SerializesAndReadsObjectNodeTreesAsLatin1()
+    {
+        UbiArtXmlNode document = UbiArtXmlDocumentWriter.Scene(
+            [
+                UbiArtXmlDocumentWriter.Actor(
+                    "Actor",
+                    new { USERFRIENDLY = "Café", DEFAULTENABLE = 1 },
+                    UbiArtXmlDocumentWriter.Component("ExampleComponent")),
+                UbiArtXmlDocumentWriter.DefaultSceneConfig()
+            ],
+            new UbiArtSceneSettings("326704", "0.500000", ViewFamily: 0, IsPopup: 0));
+
+        byte[] bytes = UbiArtXmlDocumentWriter.Write(document);
+        using MemoryStream stream = new(bytes);
+        XDocument parsed = XDocument.Load(stream);
+
+        Assert.Equal("iso-8859-1", parsed.Declaration?.Encoding, ignoreCase: true);
+        Assert.Equal("Café", parsed.Descendants("Actor").Single().Attribute("USERFRIENDLY")?.Value);
+        Assert.Contains((byte)0xE9, bytes);
+        Assert.Equal("root", UbiArtXmlDocumentWriter.Read(bytes).Name);
+    }
+}

--- a/JustDanceEditor.Formats.UbiArt.Tests/LegacyEngineContentGeneratorTests.cs
+++ b/JustDanceEditor.Formats.UbiArt.Tests/LegacyEngineContentGeneratorTests.cs
@@ -757,7 +757,9 @@ public class LegacyEngineContentGeneratorTests
         byte[] bytes = UbiArtEngineContentSerializer.Serialize(generated);
 
         Assert.IsType<string>(generated);
-        Assert.Contains("world/maps/testmap/menuart/actors/testmap_cover_generic.tpl", Encoding.UTF8.GetString(bytes));
+        string text = Encoding.UTF8.GetString(bytes);
+        Assert.Contains("enginedata/actortemplates/tpl_materialgraphiccomponent2d.tpl", text);
+        Assert.Contains("world/maps/testmap/menuart/textures/testmap_cover_generic.tga", text);
     }
 
     [Fact]

--- a/JustDanceEditor.Formats.UbiArt.Tests/LuaTableSerializerTests.cs
+++ b/JustDanceEditor.Formats.UbiArt.Tests/LuaTableSerializerTests.cs
@@ -1,0 +1,121 @@
+using JustDanceEditor.Formats.UbiArt.Model;
+using JustDanceEditor.Formats.UbiArt.Serialization;
+
+using Xunit;
+
+namespace JustDanceEditor.Formats.UbiArt.Tests;
+
+public sealed class LuaTableSerializerTests
+{
+    [Fact]
+    public void DeserializeSongDesc_NormalizesUncookedEntryTables()
+    {
+        const string lua = """
+            params = {
+                Actor_Template = {
+                    COMPONENTS = {
+                        {
+                            JD_SongDescTemplate = {
+                                MapName = "GetGetDown",
+                                JDVersion = 2021,
+                                OriginalJDVersion = 2021,
+                                PhoneImages = {
+                                    { KEY = "cover", VAL = "world/maps/getgetdown/cover.jpg" },
+                                    { KEY = "coach1", VAL = "world/maps/getgetdown/coach1.png" }
+                                },
+                                Tags = {
+                                    { VAL = "Main" },
+                                    { VAL = "Kids" }
+                                },
+                                DefaultColors = {
+                                    { KEY = "lyrics", VAL = "0xFF1B34AA" }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+            """;
+
+        SongDesc songDesc = LuaTableSerializer.Deserialize<SongDesc>(lua);
+
+        InfoComponent info = Assert.Single(songDesc.Components);
+        Assert.Equal("GetGetDown", info.MapName);
+        Assert.Equal("world/maps/getgetdown/cover.jpg", info.PhoneImages.Cover);
+        Assert.Equal("world/maps/getgetdown/coach1.png", info.PhoneImages.Coach1);
+        Assert.Equal(["Main", "Kids"], info.Tags);
+        Assert.Equal([1f, 27 / 255f, 52 / 255f, 170 / 255f], info.DefaultColors.Lyrics);
+    }
+
+    [Fact]
+    public void DeserializeSongDesc_AcceptsRegularObjectAndArrayShapes()
+    {
+        const string lua = """
+            params = {
+                Actor_Template = {
+                    COMPONENTS = {
+                        {
+                            JD_SongDescTemplate = {
+                                MapName = "RegularShapes",
+                                PhoneImages = {
+                                    Cover = "world/maps/regular/cover.jpg",
+                                    Coach1 = "world/maps/regular/coach1.png"
+                                },
+                                Tags = { "Main" },
+                                DefaultColors = {
+                                    lyrics = { 1.0, 0.1, 0.2, 0.3 },
+                                    theme = { 255, 1, 2, 3 }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+            """;
+
+        InfoComponent info = Assert.Single(LuaTableSerializer.Deserialize<SongDesc>(lua).Components);
+
+        Assert.Equal("world/maps/regular/cover.jpg", info.PhoneImages.Cover);
+        Assert.Equal("world/maps/regular/coach1.png", info.PhoneImages.Coach1);
+        Assert.Equal(["Main"], info.Tags);
+        Assert.Equal([1f, 0.1f, 0.2f, 0.3f], info.DefaultColors.Lyrics);
+        Assert.Equal([255, 1, 2, 3], info.DefaultColors.Theme);
+    }
+
+    [Fact]
+    public void DeserializeTapeEntryPaths_ReadsTapeCaseReferences()
+    {
+        const string lua = """
+            params = {
+                NAME = "Actor_Template",
+                Actor_Template = {
+                    COMPONENTS = {
+                        {
+                            NAME = "TapeCase_Template",
+                            TapeCase_Template = {
+                                TapesRack = {
+                                    {
+                                        TapeGroup = {
+                                            Entries = {
+                                                {
+                                                    TapeEntry = {
+                                                        Label = "TML_Motion",
+                                                        Path = "World/MAPS/Song/Timeline/CustomDance.dtape"
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+            """;
+
+        string path = Assert.Single(LuaTableSerializer.DeserializeTapeEntryPaths(lua));
+
+        Assert.Equal("World/MAPS/Song/Timeline/CustomDance.dtape", path);
+    }
+}

--- a/JustDanceEditor.Formats.UbiArt.Tests/SongDataLoaderTests.cs
+++ b/JustDanceEditor.Formats.UbiArt.Tests/SongDataLoaderTests.cs
@@ -96,12 +96,14 @@ public class SongDataLoaderTests
         File.WriteAllText(Path.Combine(mapsFolder, "cinematics", "song_mainsequence.tape"), "{ \"Clips\": [] }");
         Directory.CreateDirectory(Path.Combine(mapsFolder, "timeline"));
         File.WriteAllText(Path.Combine(mapsFolder, "timeline", "song_tml_dance.dtape"), "{ \"Clips\": [] }");
+        File.WriteAllText(Path.Combine(mapsFolder, "timeline", "song_tml_karaoke.ktape"), "{ \"Clips\": [] }");
         File.WriteAllText(Path.Combine(mapsFolder, "timeline", "song_tml.isc"), "<Timeline><Actor USERFRIENDLY=\"song_tml_karaoke\" LUA=\"karaoke_actor.tpl\" /></Timeline>");
 
         Directory.CreateDirectory(Path.Combine(flatSongFolder, "cinematics"));
         File.WriteAllText(Path.Combine(flatSongFolder, "cinematics", "song_mainsequence.tape"), "{ \"Clips\": [] }");
         Directory.CreateDirectory(Path.Combine(flatSongFolder, "timeline"));
         File.WriteAllText(Path.Combine(flatSongFolder, "timeline", "song_tml_dance.dtape"), "{ \"Clips\": [] }");
+        File.WriteAllText(Path.Combine(flatSongFolder, "timeline", "song_tml_karaoke.ktape"), "{ \"Clips\": [] }");
         File.WriteAllText(Path.Combine(flatSongFolder, "timeline", "song_tml.isc"), "<Timeline><Actor USERFRIENDLY=\"song_tml_karaoke\" LUA=\"karaoke_actor.tpl\" /></Timeline>");
 
         // Create karaoke actor and tape referenced by it

--- a/JustDanceEditor.Formats.UbiArt.Tests/UbiArtAudioConverterTests.cs
+++ b/JustDanceEditor.Formats.UbiArt.Tests/UbiArtAudioConverterTests.cs
@@ -1,4 +1,5 @@
 using JustDanceEditor.Formats.UbiArt.Import.Audio;
+using JustDanceEditor.Formats.UbiArt.Model;
 
 using System.IO;
 using System.Text;
@@ -27,6 +28,28 @@ public class UbiArtAudioConverterTests
         Assert.Equal(0, stream.Position);
     }
 
+    [Fact]
+    public void AudioStartOffset_UsesMarkerForPositiveStartBeat_NotVideoStartTime()
+    {
+        JDUbiArtSong song = CreateSong(
+            startBeat: 2,
+            videoStartTime: -9f,
+            markers: [0, 27168, 54336]);
+
+        Assert.Equal(-1.132f, song.GetAudioStartOffset(), precision: 6);
+    }
+
+    [Fact]
+    public void AudioStartOffset_ExtrapolatesNegativeStartBeat_NotVideoStartTimeOrAbsoluteMarker()
+    {
+        JDUbiArtSong song = CreateSong(
+            startBeat: -9,
+            videoStartTime: -0.967f,
+            markers: [0, 24000, 48000, 72000, 96000, 120000, 144000, 168000, 192000, 210911]);
+
+        Assert.Equal(4.5f, song.GetAudioStartOffset(), precision: 6);
+    }
+
     private static byte[] CreateOggHeader(string codecMarker)
     {
         byte[] data = new byte[64];
@@ -34,4 +57,26 @@ public class UbiArtAudioConverterTests
         Encoding.ASCII.GetBytes(codecMarker).CopyTo(data, 28);
         return data;
     }
+
+    private static JDUbiArtSong CreateSong(int startBeat, float videoStartTime, int[] markers) => new()
+    {
+        MusicTrack = new MusicTrack
+        {
+            Components =
+            [
+                new TrackDataHolder
+                {
+                    TrackData = new TrackData
+                    {
+                        Structure = new Structure
+                        {
+                            StartBeat = startBeat,
+                            VideoStartTime = videoStartTime,
+                            Markers = markers
+                        }
+                    }
+                }
+            ]
+        }
+    };
 }

--- a/JustDanceEditor.Formats.UbiArt.Tests/UbiArtConversionStrategyTests.cs
+++ b/JustDanceEditor.Formats.UbiArt.Tests/UbiArtConversionStrategyTests.cs
@@ -1,5 +1,6 @@
 using JustDanceEditor.Conversion.Abstractions;
 
+using System;
 using System.Linq;
 
 using Xunit;
@@ -8,6 +9,19 @@ namespace JustDanceEditor.Formats.UbiArt.Tests;
 
 public class UbiArtConversionStrategyTests
 {
+    [Fact]
+    public void GetExportTargets_ExposesThreeVersionedUncookedTargets()
+    {
+        UbiArtConversionStrategy strategy = new();
+
+        string[] targets = [.. strategy.GetExportTargets()
+            .Select(target => target.TargetCode)
+            .Where(code => code.StartsWith("uncooked-", StringComparison.Ordinal))
+            .OrderBy(code => code, StringComparer.Ordinal)];
+
+        Assert.Equal(["uncooked-2014", "uncooked-2015", "uncooked-modern"], targets);
+    }
+
     [Theory]
     [InlineData("wii-2020", ConversionSupportStatus.Stable)]
     [InlineData("ps3-2014", ConversionSupportStatus.Stable)]

--- a/JustDanceEditor.Formats.UbiArt.Tests/UbiArtIntermediateAssetWriterTests.cs
+++ b/JustDanceEditor.Formats.UbiArt.Tests/UbiArtIntermediateAssetWriterTests.cs
@@ -33,6 +33,7 @@ public sealed class UbiArtIntermediateAssetWriterTests
     [InlineData(UbiArtPlatform.Durango, UbiArtGestureFolders.Durango)]
     [InlineData(UbiArtPlatform.Orbis, UbiArtGestureFolders.Orbis)]
     [InlineData(UbiArtPlatform.Xenon, UbiArtGestureFolders.X360)]
+    [InlineData(UbiArtPlatform.Uncooked, "wii")]
     public async Task PopulateFromUbiArtAsync_CopiesGesturesToSourcePlatformFolder(UbiArtPlatform platform, string sourcePlatformFolder)
     {
         string root = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());

--- a/JustDanceEditor.Formats.UbiArt.Tests/UbiArtLayoutTests.cs
+++ b/JustDanceEditor.Formats.UbiArt.Tests/UbiArtLayoutTests.cs
@@ -276,6 +276,50 @@ public class UbiArtLayoutTests
     }
 
     [Fact]
+    public async Task JD2015UncookedExport_PreservesRawVideoAndEveryGestureFolder()
+    {
+        string root = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+        string materializedRoot = Path.Combine(root, "jdi");
+        string outputRoot = Path.Combine(root, "out");
+        byte[] videoBytes = [0, 1, 2, 3, 0xFE, 0xFF];
+
+        try
+        {
+            string videoRoot = IntermediatePackageLayout.Resolve(materializedRoot, IntermediatePackageLayout.Assets.VideoFolder);
+            string movesRoot = IntermediatePackageLayout.Resolve(materializedRoot, IntermediatePackageLayout.Assets.MovesV6Folder);
+            Directory.CreateDirectory(videoRoot);
+            Directory.CreateDirectory(movesRoot);
+            await File.WriteAllBytesAsync(Path.Combine(videoRoot, "song.mp4"), videoBytes, TestContext.Current.CancellationToken);
+            await File.WriteAllBytesAsync(Path.Combine(movesRoot, "Move_A.msm"), [4, 5, 6], TestContext.Current.CancellationToken);
+
+            foreach (string platformFolder in new[] { "durango", "orbis", "wii" })
+            {
+                string gesturesRoot = IntermediatePackageLayout.Resolve(materializedRoot, IntermediatePackageLayout.Assets.GestureFolder(platformFolder));
+                Directory.CreateDirectory(gesturesRoot);
+                await File.WriteAllTextAsync(Path.Combine(gesturesRoot, $"{platformFolder}_move.gesture"), platformFolder, TestContext.Current.CancellationToken);
+            }
+
+            UbiArtAssetWriter writer = new(NullLogger<UbiArtAssetWriter>.Instance);
+            await writer.ExportAsync(CreatePackage(), materializedRoot, outputRoot, UbiArtPlatform.Uncooked, UbiArtEngineVersion.JD2015);
+
+            string mapRoot = Path.Combine(outputRoot, "world", "maps", "jd2015", "song");
+            Assert.Equal(videoBytes, File.ReadAllBytes(Path.Combine(mapRoot, "videoscoach", "song.mp4")));
+            Assert.Contains("song.mp4", await File.ReadAllTextAsync(Path.Combine(mapRoot, "videoscoach", "video_player_main.act"), TestContext.Current.CancellationToken));
+            Assert.True(File.Exists(Path.Combine(mapRoot, "timeline", "moves", "wiiu", "move_a.msm")));
+            Assert.True(File.Exists(Path.Combine(mapRoot, "timeline", "moves", "durango", "durango_move.gesture")));
+            Assert.True(File.Exists(Path.Combine(mapRoot, "timeline", "moves", "orbis", "orbis_move.gesture")));
+            Assert.True(File.Exists(Path.Combine(mapRoot, "timeline", "moves", "wii", "wii_move.gesture")));
+            Assert.False(Directory.Exists(Path.Combine(mapRoot, "autodance")));
+            Assert.True(File.Exists(Path.Combine(outputRoot, "world", "_common", "graphic_component_templates", "graph", "textures", "background.png")));
+        }
+        finally
+        {
+            if (Directory.Exists(root))
+                Directory.Delete(root, true);
+        }
+    }
+
+    [Fact]
     public async Task JD2014Export_UsesStoredVersion5Classifier()
     {
         string root = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());

--- a/JustDanceEditor.Formats.UbiArt/Export/Generators/ModernEngineContentGenerator.cs
+++ b/JustDanceEditor.Formats.UbiArt/Export/Generators/ModernEngineContentGenerator.cs
@@ -2,6 +2,7 @@ using JustDanceEditor.Formats.JDI;
 using JustDanceEditor.Formats.JDI.Timelines;
 using JustDanceEditor.Formats.UbiArt.Import;
 using JustDanceEditor.Formats.UbiArt.Model;
+using JustDanceEditor.Formats.UbiArt.Serialization;
 
 using System.Globalization;
 using System.Text;
@@ -18,7 +19,6 @@ public class ModernEngineContentGenerator(UbiArtEngineVersion EngineVersion) : I
     };
 
     private byte[] ToBytes(string content) => Encoding.UTF8.GetBytes(content);
-    private static string ToText(object content) => Encoding.UTF8.GetString(UbiArtEngineContentSerializer.Serialize(content));
 
     #region JSON/Lua Generators
 
@@ -594,207 +594,148 @@ public class ModernEngineContentGenerator(UbiArtEngineVersion EngineVersion) : I
     {
         string mapName = package.Metadata.MapName;
         string mapNameLower = mapName.ToLowerInvariant();
-        string content = $@"<?xml version=""1.0"" encoding=""ISO-8859-1""?>
-<root>
-	<Scene ENGINE_VERSION=""326704"" GRIDUNIT=""2.000000"" DEPTH_SEPARATOR=""0"" NEAR_SEPARATOR=""1.000000 0.000000 0.000000 0.000000, 0.000000 1.000000 0.000000 0.000000, 0.000000 0.000000 1.000000 0.000000, 0.000000 0.000000 0.000000 1.000000"" FAR_SEPARATOR=""1.000000 0.000000 0.000000 0.000000, 0.000000 1.000000 0.000000 0.000000, 0.000000 0.000000 1.000000 0.000000, 0.000000 0.000000 0.000000 1.000000"" viewFamily=""0"" isPopup=""0"">
-		<PLATFORM_FILTER>
-			<TargetFilterList platform=""WII"">
-				<objects VAL=""{mapName}_AUTODANCE"" />
-			</TargetFilterList>
-		</PLATFORM_FILTER>
-		<ACTORS NAME=""SubSceneActor"">
-			<SubSceneActor RELATIVEZ=""0.000000"" SCALE=""1.000000 1.000000"" xFLIPPED=""0"" USERFRIENDLY=""{mapName}_AUDIO"" MARKER="""" DEFAULTENABLE=""1"" POS2D=""0.000000 0.000000"" ANGLE=""0.000000"" INSTANCEDATAFILE=""enginedata/actortemplates/subscene.tpl"" LUA=""enginedata/actortemplates/subscene.tpl"" RELATIVEPATH=""world/maps/{mapNameLower}/audio/{mapNameLower}_audio.isc"" EMBED_SCENE=""1"" IS_SINGLE_PIECE=""0"" ZFORCED=""1"" DIRECT_PICKING=""1"" IGNORE_SAVE=""0"">
-				<ENUM NAME=""viewType"" SEL=""2"" />
-				<SCENE>
-					{ToText(GenerateAudioScene(package)).Replace("<?xml version=\"1.0\" encoding=\"ISO-8859-1\"?>\r\n<root>\r\n", "").Replace("</root>\r\n", "")}
-				</SCENE>
-			</SubSceneActor>
-		</ACTORS>
-		<ACTORS NAME=""SubSceneActor"">
-			<SubSceneActor RELATIVEZ=""0.000000"" SCALE=""1.000000 1.000000"" xFLIPPED=""0"" USERFRIENDLY=""{mapName}_CINE"" MARKER="""" DEFAULTENABLE=""1"" POS2D=""0.000000 0.000000"" ANGLE=""0.000000"" INSTANCEDATAFILE=""enginedata/actortemplates/subscene.tpl"" LUA=""enginedata/actortemplates/subscene.tpl"" RELATIVEPATH=""world/maps/{mapNameLower}/cinematics/{mapNameLower}_cine.isc"" EMBED_SCENE=""1"" IS_SINGLE_PIECE=""0"" ZFORCED=""1"" DIRECT_PICKING=""1"" IGNORE_SAVE=""0"">
-				<ENUM NAME=""viewType"" SEL=""2"" />
-				<SCENE>
-					{ToText(GenerateCinematicsScene(package)).Replace("<?xml version=\"1.0\" encoding=\"ISO-8859-1\"?>\r\n<root>\r\n", "").Replace("</root>\r\n", "")}
-				</SCENE>
-			</SubSceneActor>
-		</ACTORS>
-		<ACTORS NAME=""SubSceneActor"">
-			<SubSceneActor RELATIVEZ=""0.000000"" SCALE=""1.000000 1.000000"" xFLIPPED=""0"" USERFRIENDLY=""{mapName}_GRAPH"" MARKER="""" DEFAULTENABLE=""1"" POS2D=""0.000000 0.000000"" ANGLE=""0.000000"" INSTANCEDATAFILE=""enginedata/actortemplates/subscene.tpl"" LUA=""enginedata/actortemplates/subscene.tpl"" RELATIVEPATH=""world/maps/{mapNameLower}/graph/{mapNameLower}_graph.isc"" EMBED_SCENE=""1"" IS_SINGLE_PIECE=""0"" ZFORCED=""1"" DIRECT_PICKING=""1"" IGNORE_SAVE=""0"">
-				<ENUM NAME=""viewType"" SEL=""2"" />
-				<SCENE>
-					{ToText(GenerateGraphScene(mapName)).Replace("<?xml version=\"1.0\" encoding=\"ISO-8859-1\"?>\r\n<root>\r\n", "").Replace("</root>\r\n", "")}
-				</SCENE>
-			</SubSceneActor>
-		</ACTORS>
-		<ACTORS NAME=""SubSceneActor"">
-			<SubSceneActor RELATIVEZ=""0.000000"" SCALE=""1.000000 1.000000"" xFLIPPED=""0"" USERFRIENDLY=""{mapName}_TML"" MARKER="""" DEFAULTENABLE=""1"" POS2D=""0.000000 0.000000"" ANGLE=""0.000000"" INSTANCEDATAFILE=""enginedata/actortemplates/subscene.tpl"" LUA=""enginedata/actortemplates/subscene.tpl"" RELATIVEPATH=""world/maps/{mapNameLower}/timeline/{mapNameLower}_tml.isc"" EMBED_SCENE=""1"" IS_SINGLE_PIECE=""0"" ZFORCED=""1"" DIRECT_PICKING=""1"" IGNORE_SAVE=""0"">
-				<ENUM NAME=""viewType"" SEL=""2"" />
-				<SCENE>
-					{ToText(GenerateTimelineScene(package)).Replace("<?xml version=\"1.0\" encoding=\"ISO-8859-1\"?>\r\n<root>\r\n", "").Replace("</root>\r\n", "")}
-				</SCENE>
-			</SubSceneActor>
-		</ACTORS>
-		<ACTORS NAME=""SubSceneActor"">
-			<SubSceneActor RELATIVEZ=""0.000000"" SCALE=""1.000000 1.000000"" xFLIPPED=""0"" USERFRIENDLY=""{mapName}_VIDEO"" MARKER="""" DEFAULTENABLE=""1"" POS2D=""0.000000 0.000000"" ANGLE=""0.000000"" INSTANCEDATAFILE=""enginedata/actortemplates/subscene.tpl"" LUA=""enginedata/actortemplates/subscene.tpl"" RELATIVEPATH=""world/maps/{mapNameLower}/videoscoach/{mapNameLower}_video.isc"" EMBED_SCENE=""1"" IS_SINGLE_PIECE=""0"" ZFORCED=""1"" DIRECT_PICKING=""1"" IGNORE_SAVE=""0"">
-				<ENUM NAME=""viewType"" SEL=""2"" />
-				<SCENE>
-					{ToText(GenerateVideoScene(mapName)).Replace("<?xml version=\"1.0\" encoding=\"ISO-8859-1\"?>\r\n<root>\r\n", "").Replace("</root>\r\n", "")}
-				</SCENE>
-			</SubSceneActor>
-		</ACTORS>
-		<ACTORS NAME=""Actor"">
-			<Actor RELATIVEZ=""0.000000"" SCALE=""1.000000 1.000000"" xFLIPPED=""0"" USERFRIENDLY=""{mapName} : SongDesc"" MARKER="""" DEFAULTENABLE=""1"" POS2D=""-3.531976 -1.485322"" ANGLE=""0.000000"" INSTANCEDATAFILE="""" LUA=""world/maps/{mapNameLower}/songdesc.tpl"">
-				<COMPONENTS NAME=""JD_SongDescComponent"">
-					<JD_SongDescComponent />
-				</COMPONENTS>
-			</Actor>
-		</ACTORS>
-		<ACTORS NAME=""SubSceneActor"">
-			<SubSceneActor RELATIVEZ=""0.000000"" SCALE=""1.000000 1.000000"" xFLIPPED=""0"" USERFRIENDLY=""{mapName}_menuart"" MARKER="""" DEFAULTENABLE=""1"" POS2D=""0.000000 0.000000"" ANGLE=""0.000000"" INSTANCEDATAFILE=""enginedata/actortemplates/subscene.tpl"" LUA=""enginedata/actortemplates/subscene.tpl"" RELATIVEPATH=""world/maps/{mapNameLower}/menuart/{mapNameLower}_menuart.isc"" EMBED_SCENE=""1"" IS_SINGLE_PIECE=""0"" ZFORCED=""1"" DIRECT_PICKING=""1"" IGNORE_SAVE=""0"">
-				<ENUM NAME=""viewType"" SEL=""3"" />
-				<SCENE>
-					{ToText(GenerateMenuArtScene(package)).Replace("<?xml version=\"1.0\" encoding=\"ISO-8859-1\"?>\r\n<root>\r\n", "").Replace("</root>", "")}
-				</SCENE>
-			</SubSceneActor>
-		</ACTORS>
-		<ACTORS NAME=""SubSceneActor"">
-			<SubSceneActor RELATIVEZ=""0.000000"" SCALE=""1.000000 1.000000"" xFLIPPED=""0"" USERFRIENDLY=""{mapName}_AUTODANCE"" MARKER="""" DEFAULTENABLE=""1"" POS2D=""0.000000 -0.033823"" ANGLE=""0.000000"" INSTANCEDATAFILE=""enginedata/actortemplates/subscene.tpl"" LUA=""enginedata/actortemplates/subscene.tpl"" RELATIVEPATH=""world/maps/{mapNameLower}/autodance/{mapNameLower}_autodance.isc"" EMBED_SCENE=""1"" IS_SINGLE_PIECE=""0"" ZFORCED=""1"" DIRECT_PICKING=""1"" IGNORE_SAVE=""0"">
-				<ENUM NAME=""viewType"" SEL=""2"" />
-				<SCENE>
-					{ToText(GenerateAutodanceScene(package)).Replace("<?xml version=\"1.0\" encoding=\"ISO-8859-1\"?>\r\n<root>\r\n", "").Replace("</root>\r\n", "")}
-				</SCENE>
-			</SubSceneActor>
-		</ACTORS>
-		<sceneConfigs>
-			<SceneConfigs activeSceneConfig=""0"">
-				<sceneConfigs NAME=""JD_MapSceneConfig"">
-					<JD_MapSceneConfig name="""" soundContext="""" hud=""0"">
-						<ENUM NAME=""Pause_Level"" SEL=""6"" />
-						<ENUM NAME=""type"" SEL=""1"" />
-						<ENUM NAME=""musicscore"" SEL=""2"" />
-					</JD_MapSceneConfig>
-				</sceneConfigs>
-			</SceneConfigs>
-		</sceneConfigs>
-	</Scene>
-</root>";
-        return ToBytes(content);
+        List<UbiArtXmlNode> children =
+        [
+            PlatformFilter("WII", $"{mapName}_AUTODANCE"),
+            EmbeddedSubScene($"{mapName}_AUDIO", $"world/maps/{mapNameLower}/audio/{mapNameLower}_audio.isc", GenerateAudioScene(package)),
+            EmbeddedSubScene($"{mapName}_CINE", $"world/maps/{mapNameLower}/cinematics/{mapNameLower}_cine.isc", GenerateCinematicsScene(package)),
+            EmbeddedSubScene($"{mapName}_GRAPH", $"world/maps/{mapNameLower}/graph/{mapNameLower}_graph.isc", GenerateGraphScene(mapName)),
+            EmbeddedSubScene($"{mapName}_TML", $"world/maps/{mapNameLower}/timeline/{mapNameLower}_tml.isc", GenerateTimelineScene(package)),
+            EmbeddedSubScene($"{mapName}_VIDEO", $"world/maps/{mapNameLower}/videoscoach/{mapNameLower}_video.isc", GenerateVideoScene(mapName)),
+            ModernActor(
+                $"{mapName} : SongDesc",
+                $"world/maps/{mapNameLower}/songdesc.tpl",
+                "JD_SongDescComponent",
+                position: "-3.531976 -1.485322"),
+            EmbeddedSubScene(
+                $"{mapName}_menuart",
+                $"world/maps/{mapNameLower}/menuart/{mapNameLower}_menuart.isc",
+                GenerateMenuArtScene(package),
+                viewType: 3),
+            EmbeddedSubScene(
+                $"{mapName}_AUTODANCE",
+                $"world/maps/{mapNameLower}/autodance/{mapNameLower}_autodance.isc",
+                GenerateAutodanceScene(package),
+                position: "0.000000 -0.033823"),
+            ModernMapSceneConfig()
+        ];
+        UbiArtSceneSettings settings = new("326704", "2.000000", ViewFamily: 0, IsPopup: 0);
+        return UbiArtXmlDocumentWriter.Write(UbiArtXmlDocumentWriter.Scene(children, settings));
     }
-
     public object GenerateAudioScene(IntermediateSongPackage package)
     {
         string mapNameLower = package.Metadata.MapName.ToLowerInvariant();
-        string content = $@"<?xml version=""1.0"" encoding=""ISO-8859-1""?>
-<root>
-    <Scene ENGINE_VERSION=""326704"" GRIDUNIT=""0.500000"" DEPTH_SEPARATOR=""0"" NEAR_SEPARATOR=""1.000000 0.000000 0.000000 0.000000, 0.000000 1.000000 0.000000 0.000000, 0.000000 0.000000 1.000000 0.000000, 0.000000 0.000000 0.000000 1.000000"" FAR_SEPARATOR=""1.000000 0.000000 0.000000 0.000000, 0.000000 1.000000 0.000000 0.000000, 0.000000 0.000000 1.000000 0.000000, 0.000000 0.000000 0.000000 1.000000"" viewFamily=""0"" isPopup=""0"">
-        <ACTORS NAME=""Actor""><Actor RELATIVEZ=""0.000000"" SCALE=""1.000000 1.000000"" xFLIPPED=""0"" USERFRIENDLY=""MusicTrack"" MARKER="""" DEFAULTENABLE=""1"" POS2D=""1.125962 -0.418641"" ANGLE=""0.000000"" INSTANCEDATAFILE="""" LUA=""world/maps/{mapNameLower}/audio/{mapNameLower}_musictrack.tpl""><COMPONENTS NAME=""MusicTrackComponent""><MusicTrackComponent /></COMPONENTS></Actor></ACTORS>
-        <ACTORS NAME=""Actor""><Actor RELATIVEZ=""0.000001"" SCALE=""1.000000 1.000000"" xFLIPPED=""0"" USERFRIENDLY=""{package.Metadata.MapName}_sequence"" MARKER="""" DEFAULTENABLE=""1"" POS2D=""-0.006158 -0.006158"" ANGLE=""0.000000"" INSTANCEDATAFILE="""" LUA=""world/maps/{mapNameLower}/audio/{mapNameLower}_sequence.tpl""><COMPONENTS NAME=""TapeCase_Component""><TapeCase_Component /></COMPONENTS></Actor></ACTORS>
-        <sceneConfigs><SceneConfigs activeSceneConfig=""0"" /></sceneConfigs>
-    </Scene>
-</root>";
-        return ToBytes(content);
+        return ModernScene(
+            ModernActor("MusicTrack", $"world/maps/{mapNameLower}/audio/{mapNameLower}_musictrack.tpl", "MusicTrackComponent", position: "1.125962 -0.418641"),
+            ModernActor($"{package.Metadata.MapName}_sequence", $"world/maps/{mapNameLower}/audio/{mapNameLower}_sequence.tpl", "TapeCase_Component", relativeZ: "0.000001", position: "-0.006158 -0.006158"));
     }
 
     public object GenerateTimelineScene(IntermediateSongPackage package)
     {
         string mapNameLower = package.Metadata.MapName.ToLowerInvariant();
-        string content = $@"<?xml version=""1.0"" encoding=""ISO-8859-1""?>
-<root>
-    <Scene ENGINE_VERSION=""326704"" GRIDUNIT=""0.500000"" DEPTH_SEPARATOR=""0"" NEAR_SEPARATOR=""1.000000 0.000000 0.000000 0.000000, 0.000000 1.000000 0.000000 0.000000, 0.000000 0.000000 1.000000 0.000000, 0.000000 0.000000 0.000000 1.000000"" FAR_SEPARATOR=""1.000000 0.000000 0.000000 0.000000, 0.000000 1.000000 0.000000 0.000000, 0.000000 0.000000 1.000000 0.000000, 0.000000 0.000000 0.000000 1.000000"" viewFamily=""0"" isPopup=""0"">
-        <ACTORS NAME=""Actor""><Actor RELATIVEZ=""0.000001"" SCALE=""1.000000 1.000000"" xFLIPPED=""0"" USERFRIENDLY=""{package.Metadata.MapName}_tml_dance"" MARKER="""" DEFAULTENABLE=""1"" POS2D=""-1.157740 0.006158"" ANGLE=""0.000000"" INSTANCEDATAFILE="""" LUA=""world/maps/{mapNameLower}/timeline/{mapNameLower}_tml_dance.tpl""><COMPONENTS NAME=""TapeCase_Component""><TapeCase_Component /></COMPONENTS></Actor></ACTORS>
-        <ACTORS NAME=""Actor""><Actor RELATIVEZ=""0.000001"" SCALE=""1.000000 1.000000"" xFLIPPED=""0"" USERFRIENDLY=""{package.Metadata.MapName}_tml_karaoke"" MARKER="""" DEFAULTENABLE=""1"" POS2D=""-1.157740 0.006158"" ANGLE=""0.000000"" INSTANCEDATAFILE="""" LUA=""world/maps/{mapNameLower}/timeline/{mapNameLower}_tml_karaoke.tpl""><COMPONENTS NAME=""TapeCase_Component""><TapeCase_Component /></COMPONENTS></Actor></ACTORS>
-        <sceneConfigs><SceneConfigs activeSceneConfig=""0"" /></sceneConfigs>
-    </Scene>
-</root>";
-        return ToBytes(content);
+        return ModernScene(
+            ModernActor($"{package.Metadata.MapName}_tml_dance", $"world/maps/{mapNameLower}/timeline/{mapNameLower}_tml_dance.tpl", "TapeCase_Component", relativeZ: "0.000001", position: "-1.157740 0.006158"),
+            ModernActor($"{package.Metadata.MapName}_tml_karaoke", $"world/maps/{mapNameLower}/timeline/{mapNameLower}_tml_karaoke.tpl", "TapeCase_Component", relativeZ: "0.000001", position: "-1.157740 0.006158"));
     }
 
     public object GenerateCinematicsScene(IntermediateSongPackage package)
     {
         string mapNameLower = package.Metadata.MapName.ToLowerInvariant();
-        string content = $@"<?xml version=""1.0"" encoding=""ISO-8859-1""?>
-<root>
-    <Scene ENGINE_VERSION=""326704"" GRIDUNIT=""0.500000"" DEPTH_SEPARATOR=""0"" NEAR_SEPARATOR=""1.000000 0.000000 0.000000 0.000000, 0.000000 1.000000 0.000000 0.000000, 0.000000 0.000000 1.000000 0.000000, 0.000000 0.000000 0.000000 1.000000"" FAR_SEPARATOR=""1.000000 0.000000 0.000000 0.000000, 0.000000 1.000000 0.000000 0.000000, 0.000000 0.000000 1.000000 0.000000, 0.000000 0.000000 0.000000 1.000000"" viewFamily=""0"" isPopup=""0"">
-        <ACTORS NAME=""Actor""><Actor RELATIVEZ=""0.000000"" SCALE=""1.000000 1.000000"" xFLIPPED=""0"" USERFRIENDLY=""{package.Metadata.MapName}_MainSequence"" MARKER="""" DEFAULTENABLE=""1"" POS2D=""0.000000 0.000000"" ANGLE=""0.000000"" INSTANCEDATAFILE="""" LUA=""world/maps/{mapNameLower}/cinematics/{mapNameLower}_mainsequence.tpl""><COMPONENTS NAME=""MasterTape""><MasterTape /></COMPONENTS></Actor></ACTORS>
-        <sceneConfigs><SceneConfigs activeSceneConfig=""0"" /></sceneConfigs>
-    </Scene>
-</root>";
-        return ToBytes(content);
+        return ModernScene(ModernActor(
+            $"{package.Metadata.MapName}_MainSequence",
+            $"world/maps/{mapNameLower}/cinematics/{mapNameLower}_mainsequence.tpl",
+            "MasterTape"));
     }
 
     public object GenerateMenuArtScene(IntermediateSongPackage package)
     {
         string mapName = package.Metadata.MapName;
         string mapNameLower = mapName.ToLowerInvariant();
-        string content = $@"<?xml version=""1.0"" encoding=""ISO-8859-1""?>
-<root>
-    <Scene ENGINE_VERSION=""326704"" GRIDUNIT=""0.500000"" DEPTH_SEPARATOR=""0"" NEAR_SEPARATOR=""1.000000 0.000000 0.000000 0.000000, 0.000000 1.000000 0.000000 0.000000, 0.000000 0.000000 1.000000 0.000000, 0.000000 0.000000 0.000000 1.000000"" FAR_SEPARATOR=""1.000000 0.000000 0.000000 0.000000, 0.000000 1.000000 0.000000 0.000000, 0.000000 0.000000 1.000000 0.000000, 0.000000 0.000000 0.000000 1.000000"" viewFamily=""1"" isPopup=""0"">
-        <PLATFORM_FILTER><TargetFilterList platform=""WIIU""><objects VAL=""{mapName}_cover_generic"" /><objects VAL=""{mapName}_cover_albumbkg"" /></TargetFilterList></PLATFORM_FILTER>
-        <PLATFORM_FILTER><TargetFilterList platform=""ORBIS""><objects VAL=""{mapName}_cover_generic"" /><objects VAL=""{mapName}_cover_albumbkg"" /></TargetFilterList></PLATFORM_FILTER>
-        <ACTORS NAME=""Actor""><Actor RELATIVEZ=""0.000000"" SCALE=""0.300000 0.300000"" xFLIPPED=""0"" USERFRIENDLY=""{mapName}_cover_generic"" MARKER="""" DEFAULTENABLE=""1"" POS2D=""266.087555 197.629959"" ANGLE=""0.000000"" INSTANCEDATAFILE="""" LUA=""enginedata/actortemplates/tpl_materialgraphiccomponent2d.tpl""><COMPONENTS NAME=""MaterialGraphicComponent""><MaterialGraphicComponent><material><GFXMaterialSerializable><textureSet><GFXMaterialTexturePathSet diffuse=""world/maps/{mapNameLower}/menuart/textures/{mapNameLower}_cover_generic.tga"" /></textureSet></GFXMaterialSerializable></material></MaterialGraphicComponent></COMPONENTS></Actor></ACTORS>
-        <ACTORS NAME=""Actor""><Actor RELATIVEZ=""0.000000"" SCALE=""0.300000 0.300000"" xFLIPPED=""0"" USERFRIENDLY=""{mapName}_cover_online"" MARKER="""" DEFAULTENABLE=""1"" POS2D=""-150.000000 0.000000"" ANGLE=""0.000000"" INSTANCEDATAFILE="""" LUA=""enginedata/actortemplates/tpl_materialgraphiccomponent2d.tpl""><COMPONENTS NAME=""MaterialGraphicComponent""><MaterialGraphicComponent><material><GFXMaterialSerializable><textureSet><GFXMaterialTexturePathSet diffuse=""world/maps/{mapNameLower}/menuart/textures/{mapNameLower}_cover_online.tga"" /></textureSet></GFXMaterialSerializable></material></MaterialGraphicComponent></COMPONENTS></Actor></ACTORS>
-        <ACTORS NAME=""Actor""><Actor RELATIVEZ=""0.000000"" SCALE=""0.300000 0.300000"" xFLIPPED=""0"" USERFRIENDLY=""{mapName}_cover_albumcoach"" MARKER="""" DEFAULTENABLE=""1"" POS2D=""738.106323 359.612030"" ANGLE=""0.000000"" INSTANCEDATAFILE="""" LUA=""enginedata/actortemplates/tpl_materialgraphiccomponent2d.tpl""><COMPONENTS NAME=""MaterialGraphicComponent""><MaterialGraphicComponent><material><GFXMaterialSerializable><textureSet><GFXMaterialTexturePathSet diffuse=""world/maps/{mapNameLower}/menuart/textures/{mapNameLower}_cover_albumcoach.tga"" /></textureSet></GFXMaterialSerializable></material></MaterialGraphicComponent></COMPONENTS></Actor></ACTORS>
-        <ACTORS NAME=""Actor""><Actor RELATIVEZ=""0.000000"" SCALE=""0.300000 0.300000"" xFLIPPED=""0"" USERFRIENDLY=""{mapName}_cover_albumbkg"" MARKER="""" DEFAULTENABLE=""1"" POS2D=""1067.972168 201.986328"" ANGLE=""0.000000"" INSTANCEDATAFILE="""" LUA=""enginedata/actortemplates/tpl_materialgraphiccomponent2d.tpl""><COMPONENTS NAME=""MaterialGraphicComponent""><MaterialGraphicComponent><material><GFXMaterialSerializable><textureSet><GFXMaterialTexturePathSet diffuse=""world/maps/{mapNameLower}/menuart/textures/{mapNameLower}_cover_albumbkg.tga"" /></textureSet></GFXMaterialSerializable></material></MaterialGraphicComponent></COMPONENTS></Actor></ACTORS>
-        <ACTORS NAME=""Actor""><Actor RELATIVEZ=""0.000000"" SCALE=""256.000000 128.000000"" xFLIPPED=""0"" USERFRIENDLY=""{mapName}_banner_bkg"" MARKER="""" DEFAULTENABLE=""1"" POS2D=""1487.410156 -32.732918"" ANGLE=""0.000000"" INSTANCEDATAFILE="""" LUA=""enginedata/actortemplates/tpl_materialgraphiccomponent2d.tpl""><COMPONENTS NAME=""MaterialGraphicComponent""><MaterialGraphicComponent><material><GFXMaterialSerializable><textureSet><GFXMaterialTexturePathSet diffuse=""world/maps/{mapNameLower}/menuart/textures/{mapNameLower}_banner_bkg.tga"" /></textureSet></GFXMaterialSerializable></material></MaterialGraphicComponent></COMPONENTS></Actor></ACTORS>
-        <ACTORS NAME=""Actor""><Actor RELATIVEZ=""0.000000"" SCALE=""0.290211 0.290211"" xFLIPPED=""0"" USERFRIENDLY=""{mapName}_coach_1"" MARKER="""" DEFAULTENABLE=""1"" POS2D=""212.784500 663.680176"" ANGLE=""0.000000"" INSTANCEDATAFILE="""" LUA=""enginedata/actortemplates/tpl_materialgraphiccomponent2d.tpl""><COMPONENTS NAME=""MaterialGraphicComponent""><MaterialGraphicComponent><material><GFXMaterialSerializable><textureSet><GFXMaterialTexturePathSet diffuse=""world/maps/{mapNameLower}/menuart/textures/{mapNameLower}_coach_1.tga"" /></textureSet></GFXMaterialSerializable></material></MaterialGraphicComponent></COMPONENTS></Actor></ACTORS>
-        <ACTORS NAME=""Actor""><Actor RELATIVEZ=""0.000000"" SCALE=""256.000000 128.000000"" xFLIPPED=""0"" USERFRIENDLY=""{mapName}_map_bkg"" MARKER="""" DEFAULTENABLE=""1"" POS2D=""1487.410034 350.000000"" ANGLE=""0.000000"" INSTANCEDATAFILE="""" LUA=""enginedata/actortemplates/tpl_materialgraphiccomponent2d.tpl""><COMPONENTS NAME=""MaterialGraphicComponent""><MaterialGraphicComponent><material><GFXMaterialSerializable><textureSet><GFXMaterialTexturePathSet diffuse=""world/maps/{mapNameLower}/menuart/textures/{mapNameLower}_map_bkg.tga"" /></textureSet></GFXMaterialSerializable></material></MaterialGraphicComponent></COMPONENTS></Actor></ACTORS>
-        <sceneConfigs><SceneConfigs activeSceneConfig=""0"" /></sceneConfigs>
-    </Scene>
-</root>";
-        return ToBytes(content);
+        string textureRoot = $"world/maps/{mapNameLower}/menuart/textures";
+        List<UbiArtXmlNode> children =
+        [
+            PlatformFilter("WIIU", $"{mapName}_cover_generic", $"{mapName}_cover_albumbkg"),
+            PlatformFilter("ORBIS", $"{mapName}_cover_generic", $"{mapName}_cover_albumbkg"),
+            ModernMaterialActor($"{mapName}_cover_generic", $"{textureRoot}/{mapNameLower}_cover_generic.tga", "0.300000 0.300000", "266.087555 197.629959"),
+            ModernMaterialActor($"{mapName}_cover_online", $"{textureRoot}/{mapNameLower}_cover_online.tga", "0.300000 0.300000", "-150.000000 0.000000"),
+            ModernMaterialActor($"{mapName}_cover_albumcoach", $"{textureRoot}/{mapNameLower}_cover_albumcoach.tga", "0.300000 0.300000", "738.106323 359.612030"),
+            ModernMaterialActor($"{mapName}_cover_albumbkg", $"{textureRoot}/{mapNameLower}_cover_albumbkg.tga", "0.300000 0.300000", "1067.972168 201.986328"),
+            ModernMaterialActor($"{mapName}_banner_bkg", $"{textureRoot}/{mapNameLower}_banner_bkg.tga", "256.000000 128.000000", "1487.410156 -32.732918"),
+            ModernMaterialActor($"{mapName}_coach_1", $"{textureRoot}/{mapNameLower}_coach_1.tga", "0.290211 0.290211", "212.784500 663.680176"),
+            ModernMaterialActor($"{mapName}_map_bkg", $"{textureRoot}/{mapNameLower}_map_bkg.tga", "256.000000 128.000000", "1487.410034 350.000000"),
+            UbiArtXmlDocumentWriter.DefaultSceneConfig()
+        ];
+        UbiArtSceneSettings settings = new("326704", "0.500000", ViewFamily: 1, IsPopup: 0);
+        return UbiArtXmlDocumentWriter.Write(UbiArtXmlDocumentWriter.Scene(children, settings));
     }
-
     public object GenerateAutodanceScene(IntermediateSongPackage package)
     {
         string mapName = package.Metadata.MapName;
         string mapNameLower = mapName.ToLowerInvariant();
-        string content = $@"<?xml version=""1.0"" encoding=""ISO-8859-1""?>
-<root>
-    <Scene ENGINE_VERSION=""326704"" GRIDUNIT=""0.500000"" DEPTH_SEPARATOR=""0"" NEAR_SEPARATOR=""1.000000 0.000000 0.000000 0.000000, 0.000000 1.000000 0.000000 0.000000, 0.000000 0.000000 1.000000 0.000000, 0.000000 0.000000 0.000000 1.000000"" FAR_SEPARATOR=""1.000000 0.000000 0.000000 0.000000, 0.000000 1.000000 0.000000 0.000000, 0.000000 0.000000 1.000000 0.000000, 0.000000 0.000000 0.000000 1.000000"" viewFamily=""0"" isPopup=""0"">
-        <ACTORS NAME=""Actor""><Actor RELATIVEZ=""0.000000"" SCALE=""1.000000 1.000000"" xFLIPPED=""0"" USERFRIENDLY=""{mapName}_Autodance"" MARKER="""" DEFAULTENABLE=""1"" POS2D=""0.000000 0.000000"" ANGLE=""0.000000"" INSTANCEDATAFILE="""" LUA=""world/maps/{mapNameLower}/autodance/{mapNameLower}_autodance.tpl""><COMPONENTS NAME=""JD_AutodanceComponent""><JD_AutodanceComponent /></COMPONENTS></Actor></ACTORS>
-        <sceneConfigs><SceneConfigs activeSceneConfig=""0"" /></sceneConfigs>
-    </Scene>
-</root>";
-        return ToBytes(content);
+        return ModernScene(ModernActor(
+            $"{mapName}_Autodance",
+            $"world/maps/{mapNameLower}/autodance/{mapNameLower}_autodance.tpl",
+            "JD_AutodanceComponent"));
     }
 
     public object GenerateGraphScene(string mapName)
     {
-        string content = $@"<?xml version=""1.0"" encoding=""ISO-8859-1""?>
-<root>
-    <Scene ENGINE_VERSION=""326704"" GRIDUNIT=""0.500000"" DEPTH_SEPARATOR=""0"" NEAR_SEPARATOR=""1.000000 0.000000 0.000000 0.000000, 0.000000 1.000000 0.000000 0.000000, 0.000000 0.000000 1.000000 0.000000, 0.000000 0.000000 0.000000 1.000000"" FAR_SEPARATOR=""1.000000 0.000000 0.000000 0.000000, 0.000000 1.000000 0.000000 0.000000, 0.000000 0.000000 1.000000 0.000000, 0.000000 0.000000 0.000000 1.000000"" viewFamily=""0"" isPopup=""0"">
-        <ACTORS NAME=""Actor""><Actor RELATIVEZ=""10.000000"" SCALE=""1.000000 1.000000"" xFLIPPED=""0"" USERFRIENDLY=""Camera_JD_Dummy"" MARKER="""" DEFAULTENABLE=""1"" POS2D=""0.000000 0.000000"" ANGLE=""0.000000"" INSTANCEDATAFILE=""enginedata/actortemplates/tpl_emptyactor.tpl"" LUA=""enginedata/actortemplates/tpl_emptyactor.tpl"" /></ACTORS>
-        <sceneConfigs><SceneConfigs activeSceneConfig=""0"" /></sceneConfigs>
-    </Scene>
-</root>";
-        return ToBytes(content);
+        return ModernScene(UbiArtXmlDocumentWriter.Actor(
+            "Actor",
+            ModernActorAttributes(
+                "Camera_JD_Dummy",
+                "enginedata/actortemplates/tpl_emptyactor.tpl",
+                instanceDataFile: "enginedata/actortemplates/tpl_emptyactor.tpl",
+                relativeZ: "10.000000")));
     }
 
     public object GenerateVideoScene(string mapName)
     {
         string mapNameLower = mapName.ToLowerInvariant();
-        string content = $@"<?xml version=""1.0"" encoding=""ISO-8859-1""?>
-<root>
-    <Scene ENGINE_VERSION=""326704"" GRIDUNIT=""0.500000"" DEPTH_SEPARATOR=""0"" NEAR_SEPARATOR=""1.000000 0.000000 0.000000 0.000000, 0.000000 1.000000 0.000000 0.000000, 0.000000 0.000000 1.000000 0.000000, 0.000000 0.000000 0.000000 1.000000"" FAR_SEPARATOR=""1.000000 0.000000 0.000000 0.000000, 0.000000 1.000000 0.000000 0.000000, 0.000000 0.000000 1.000000 0.000000, 0.000000 0.000000 0.000000 1.000000"" viewFamily=""0"" isPopup=""0"">
-        <ACTORS NAME=""Actor""><Actor RELATIVEZ=""-1.000000"" SCALE=""1.000000 1.000000"" xFLIPPED=""0"" USERFRIENDLY=""VideoScreen"" MARKER="""" DEFAULTENABLE=""1"" POS2D=""0.000000 -4.500000"" ANGLE=""0.000000"" INSTANCEDATAFILE="""" LUA=""world/_common/videoscreen/video_player_main.tpl""><COMPONENTS NAME=""PleoComponent""><PleoComponent video=""world/maps/{mapNameLower}/videoscoach/{mapNameLower}.webm"" dashMPD=""world/maps/{mapNameLower}/videoscoach/{mapNameLower}.mpd"" /></COMPONENTS></Actor></ACTORS>
-        <ACTORS NAME=""Actor""><Actor RELATIVEZ=""0.000000"" SCALE=""3.941238 2.220000"" xFLIPPED=""0"" USERFRIENDLY=""VideoOutput"" MARKER="""" DEFAULTENABLE=""1"" POS2D=""0.000000 0.000000"" ANGLE=""0.000000"" INSTANCEDATAFILE="""" LUA=""world/_common/videoscreen/video_output_main.tpl""><COMPONENTS NAME=""PleoTextureGraphicComponent""><PleoTextureGraphicComponent><material><GFXMaterialSerializable><textureSet><GFXMaterialTexturePathSet /></textureSet></GFXMaterialSerializable></material></PleoTextureGraphicComponent></COMPONENTS></Actor></ACTORS>
-        <sceneConfigs><SceneConfigs activeSceneConfig=""0"" /></sceneConfigs>
-    </Scene>
-</root>";
-        return ToBytes(content);
+        UbiArtXmlNode pleo = UbiArtXmlDocumentWriter.Component(
+            "PleoComponent",
+            UbiArtXmlDocumentWriter.Node("PleoComponent", new
+            {
+                video = $"world/maps/{mapNameLower}/videoscoach/{mapNameLower}.webm",
+                dashMPD = $"world/maps/{mapNameLower}/videoscoach/{mapNameLower}.mpd"
+            }));
+        UbiArtXmlNode material = UbiArtXmlDocumentWriter.Node(
+            "material",
+            null,
+            UbiArtXmlDocumentWriter.Node(
+                "GFXMaterialSerializable",
+                null,
+                UbiArtXmlDocumentWriter.Node(
+                    "textureSet",
+                    null,
+                    UbiArtXmlDocumentWriter.Node("GFXMaterialTexturePathSet"))));
+        UbiArtXmlNode output = UbiArtXmlDocumentWriter.Component("PleoTextureGraphicComponent", material);
+        return ModernScene(
+            UbiArtXmlDocumentWriter.Actor(
+                "Actor",
+                ModernActorAttributes("VideoScreen", "world/_common/videoscreen/video_player_main.tpl", relativeZ: "-1.000000", position: "0.000000 -4.500000"),
+                pleo),
+            UbiArtXmlDocumentWriter.Actor(
+                "Actor",
+                ModernActorAttributes("VideoOutput", "world/_common/videoscreen/video_output_main.tpl", scale: "3.941238 2.220000"),
+                output));
     }
 
     public object GenerateVideoMapPreviewScene(string mapName)
     {
         string mapNameLower = mapName.ToLowerInvariant();
-        string content = $@"<?xml version=""1.0"" encoding=""ISO-8859-1""?>
-<root>
-    <Scene ENGINE_VERSION=""326704"" GRIDUNIT=""0.500000"" DEPTH_SEPARATOR=""0"" NEAR_SEPARATOR=""1.000000 0.000000 0.000000 0.000000, 0.000000 1.000000 0.000000 0.000000, 0.000000 0.000000 1.000000 0.000000, 0.000000 0.000000 0.000000 1.000000"" FAR_SEPARATOR=""1.000000 0.000000 0.000000 0.000000, 0.000000 1.000000 0.000000 0.000000, 0.000000 0.000000 1.000000 0.000000, 0.000000 0.000000 0.000000 1.000000"" viewFamily=""0"" isPopup=""0"">
-        <ACTORS NAME=""Actor""><Actor RELATIVEZ=""-1.000000"" SCALE=""1.000000 1.000000"" xFLIPPED=""0"" USERFRIENDLY=""VideoScreen"" MARKER="""" DEFAULTENABLE=""1"" POS2D=""0.000000 -4.500000"" ANGLE=""0.000000"" INSTANCEDATAFILE="""" LUA=""world/_common/videoscreen/video_player_map_preview.tpl""><COMPONENTS NAME=""PleoComponent""><PleoComponent video=""world/maps/{mapNameLower}/videoscoach/{mapNameLower}.webm"" dashMPD=""world/maps/{mapNameLower}/videoscoach/{mapNameLower}.mpd"" channelID=""{mapName}"" /></COMPONENTS></Actor></ACTORS>
-        <sceneConfigs><SceneConfigs activeSceneConfig=""0"" /></sceneConfigs>
-    </Scene>
-</root>";
-        return ToBytes(content);
+        UbiArtXmlNode pleo = UbiArtXmlDocumentWriter.Component(
+            "PleoComponent",
+            UbiArtXmlDocumentWriter.Node("PleoComponent", new
+            {
+                video = $"world/maps/{mapNameLower}/videoscoach/{mapNameLower}.webm",
+                dashMPD = $"world/maps/{mapNameLower}/videoscoach/{mapNameLower}.mpd",
+                channelID = mapName
+            }));
+        return ModernScene(UbiArtXmlDocumentWriter.Actor(
+            "Actor",
+            ModernActorAttributes("VideoScreen", "world/_common/videoscreen/video_player_map_preview.tpl", relativeZ: "-1.000000", position: "0.000000 -4.500000"),
+            pleo));
     }
 
     #endregion
@@ -819,6 +760,130 @@ public class ModernEngineContentGenerator(UbiArtEngineVersion EngineVersion) : I
     public virtual object GenerateMenuArtActor(string textureName, string mapName)
     {
         return new UbiArtMenuArtActorFile(textureName, mapName, UbiArtMenuArtActorVersion.Modern);
+    }
+
+    private static byte[] ModernScene(params UbiArtXmlNode[] actors)
+    {
+        List<UbiArtXmlNode> children = [.. actors, UbiArtXmlDocumentWriter.DefaultSceneConfig()];
+        UbiArtSceneSettings settings = new("326704", "0.500000", ViewFamily: 0, IsPopup: 0);
+        return UbiArtXmlDocumentWriter.Write(UbiArtXmlDocumentWriter.Scene(children, settings));
+    }
+
+    private static UbiArtXmlNode ModernActor(
+        string userFriendly,
+        string lua,
+        string componentName,
+        string relativeZ = "0.000000",
+        string position = "0.000000 0.000000") =>
+        UbiArtXmlDocumentWriter.Actor(
+            "Actor",
+            ModernActorAttributes(userFriendly, lua, relativeZ: relativeZ, position: position),
+            UbiArtXmlDocumentWriter.Component(componentName));
+
+    private static object ModernActorAttributes(
+        string userFriendly,
+        string lua,
+        string instanceDataFile = "",
+        string relativeZ = "0.000000",
+        string scale = "1.000000 1.000000",
+        string position = "0.000000 0.000000") => new
+    {
+        RELATIVEZ = relativeZ,
+        SCALE = scale,
+        xFLIPPED = 0,
+        USERFRIENDLY = userFriendly,
+        MARKER = "",
+        DEFAULTENABLE = 1,
+        POS2D = position,
+        ANGLE = "0.000000",
+        INSTANCEDATAFILE = instanceDataFile,
+        LUA = lua
+    };
+
+    private static UbiArtXmlNode PlatformFilter(string platform, params string[] objects) =>
+        UbiArtXmlDocumentWriter.Node(
+            "PLATFORM_FILTER",
+            null,
+            UbiArtXmlDocumentWriter.Node(
+                "TargetFilterList",
+                new { platform },
+                [.. objects.Select(value => UbiArtXmlDocumentWriter.Node("objects", new { VAL = value }))]));
+
+    private static UbiArtXmlNode EmbeddedSubScene(
+        string userFriendly,
+        string relativePath,
+        object sceneContent,
+        int viewType = 2,
+        string position = "0.000000 0.000000")
+    {
+        UbiArtXmlNode root = UbiArtXmlDocumentWriter.Read(UbiArtEngineContentSerializer.Serialize(sceneContent));
+        UbiArtXmlNode scene = root.Children.Single(child => child.Name == "Scene");
+        return UbiArtXmlDocumentWriter.Actor(
+            "SubSceneActor",
+            new
+            {
+                RELATIVEZ = "0.000000",
+                SCALE = "1.000000 1.000000",
+                xFLIPPED = 0,
+                USERFRIENDLY = userFriendly,
+                MARKER = "",
+                DEFAULTENABLE = 1,
+                POS2D = position,
+                ANGLE = "0.000000",
+                INSTANCEDATAFILE = "enginedata/actortemplates/subscene.tpl",
+                LUA = "enginedata/actortemplates/subscene.tpl",
+                RELATIVEPATH = relativePath,
+                EMBED_SCENE = 1,
+                IS_SINGLE_PIECE = 0,
+                ZFORCED = 1,
+                DIRECT_PICKING = 1,
+                IGNORE_SAVE = 0
+            },
+            UbiArtXmlDocumentWriter.Node("ENUM", new { NAME = "viewType", SEL = viewType }),
+            UbiArtXmlDocumentWriter.Node("SCENE", null, scene));
+    }
+
+    private static UbiArtXmlNode ModernMaterialActor(
+        string userFriendly,
+        string texturePath,
+        string scale,
+        string position)
+    {
+        UbiArtXmlNode material = UbiArtXmlDocumentWriter.Node(
+            "material",
+            null,
+            UbiArtXmlDocumentWriter.Node(
+                "GFXMaterialSerializable",
+                null,
+                UbiArtXmlDocumentWriter.Node(
+                    "textureSet",
+                    null,
+                    UbiArtXmlDocumentWriter.Node("GFXMaterialTexturePathSet", new { diffuse = texturePath }))));
+        return UbiArtXmlDocumentWriter.Actor(
+            "Actor",
+            ModernActorAttributes(
+                userFriendly,
+                "enginedata/actortemplates/tpl_materialgraphiccomponent2d.tpl",
+                scale: scale,
+                position: position),
+            UbiArtXmlDocumentWriter.Component("MaterialGraphicComponent", material));
+    }
+
+    private static UbiArtXmlNode ModernMapSceneConfig()
+    {
+        UbiArtXmlNode mapConfig = UbiArtXmlDocumentWriter.Node(
+            "JD_MapSceneConfig",
+            new { name = "", soundContext = "", hud = 0 },
+            UbiArtXmlDocumentWriter.Node("ENUM", new { NAME = "Pause_Level", SEL = 6 }),
+            UbiArtXmlDocumentWriter.Node("ENUM", new { NAME = "type", SEL = 1 }),
+            UbiArtXmlDocumentWriter.Node("ENUM", new { NAME = "musicscore", SEL = 2 }));
+        return UbiArtXmlDocumentWriter.Node(
+            "sceneConfigs",
+            null,
+            UbiArtXmlDocumentWriter.Node(
+                "SceneConfigs",
+                new { activeSceneConfig = 0 },
+                UbiArtXmlDocumentWriter.Node("sceneConfigs", new { NAME = "JD_MapSceneConfig" }, mapConfig)));
     }
 
     private static float[] ConvertColorToArray(string hexColor)

--- a/JustDanceEditor.Formats.UbiArt/Export/Generators/UncookedEngineContentGenerator.cs
+++ b/JustDanceEditor.Formats.UbiArt/Export/Generators/UncookedEngineContentGenerator.cs
@@ -1,8 +1,10 @@
 using JustDanceEditor.Formats.JDI;
 using JustDanceEditor.Formats.JDI.Timelines;
+using JustDanceEditor.Formats.UbiArt.Import;
 using JustDanceEditor.Formats.UbiArt.Serialization;
 
 using System.Reflection;
+using System.Globalization;
 using System.Text;
 
 namespace JustDanceEditor.Formats.UbiArt.Export.Generators;
@@ -11,12 +13,14 @@ namespace JustDanceEditor.Formats.UbiArt.Export.Generators;
 /// Engine content generator that produces Lua-formatted output for Uncooked UbiArt packages.
 /// Uncooked packages are raw, human-readable project files used during development and modding.
 /// </summary>
-public class UncookedEngineContentGenerator : IEngineContentGenerator
+public class UncookedEngineContentGenerator(UbiArtEngineVersion version = UbiArtEngineVersion.JD2022) : IEngineContentGenerator
 {
     private const long PictoTrackId = 1272115770L;
     private const long GoldEffectTrackId = 628418524L;
 
     private static byte[] ToBytes(string content) => Encoding.UTF8.GetBytes(content);
+
+    public string? VideoFileName { get; set; }
 
     #region Lua Content Generators
 
@@ -25,20 +29,8 @@ public class UncookedEngineContentGenerator : IEngineContentGenerator
         string mapName = package.Metadata.MapName;
         string artist = EscapeLuaString(package.Metadata.Artist);
         string title = EscapeLuaString(package.Metadata.Title);
-        string numCoach = package.Metadata.CoachCount switch
-        {
-            1 => "NumCoach.Solo",
-            2 => "NumCoach.Duo",
-            3 => "NumCoach.Trio",
-            _ => "NumCoach.Quatuor"
-        };
-        string difficulty = package.Metadata.Difficulty switch
-        {
-            1 => "SongDifficulty.Easy",
-            2 => "SongDifficulty.Normal",
-            3 => "SongDifficulty.Hard",
-            _ => "SongDifficulty.Extreme"
-        };
+        string mapNameLower = mapName.ToLowerInvariant();
+        string mapRoot = GetMapRoot(mapNameLower);
 
         StringBuilder sb = new();
         sb.AppendLine("includeReference(\"EngineData/Helpers/SongDatabase.ilu\")");
@@ -61,14 +53,32 @@ public class UncookedEngineContentGenerator : IEngineContentGenerator
         sb.AppendLine("        JD_SongDescTemplate =");
         sb.AppendLine("        {");
         sb.AppendLine($"\t\t\tMapName\t\t\t\t\t\t=\t\t\"{mapName}\",");
-        sb.AppendLine($"\t\t\tJDVersion\t\t\t\t\t=\t\t{package.Metadata.OriginalJDVersion},");
+        sb.AppendLine($"\t\t\tJDVersion\t\t\t\t\t=\t\t{(int)version},");
+        sb.AppendLine($"\t\t\tOriginalJDVersion\t\t\t=\t\t{package.Metadata.OriginalJDVersion},");
         sb.AppendLine("\t\t\tRelatedAlbums\t\t\t\t=\t\t");
         sb.AppendLine("\t\t\t{");
         sb.AppendLine("\t\t\t},");
         sb.AppendLine($"\t\t\tArtist\t\t\t\t\t\t=\t\t\"{artist}\",");
         sb.AppendLine($"\t\t\tTitle\t\t\t\t\t\t=\t\t\"{title}\",");
-        sb.AppendLine($"\t\t\tNumCoach\t\t\t\t\t=\t\t{numCoach},");
-        sb.AppendLine($"\t\t\tDifficulty\t\t\t\t\t=\t\t{difficulty},");
+        sb.AppendLine($"\t\t\tCredits\t\t\t\t\t\t=\t\t\"{EscapeLuaString(package.Metadata.Credits)}\",");
+        sb.AppendLine("\t\t\tPhoneImages =");
+        sb.AppendLine("\t\t\t{");
+        sb.AppendLine($"\t\t\t\t{{ KEY = \"cover\", VAL = \"{mapRoot}/menuart/textures/{mapNameLower}_cover_phone.png\" }},");
+        for (int coachIndex = 1; coachIndex <= package.Metadata.CoachCount; coachIndex++)
+            sb.AppendLine($"\t\t\t\t{{ KEY = \"coach{coachIndex}\", VAL = \"{mapRoot}/menuart/textures/{mapNameLower}_coach_{coachIndex}_phone.png\" }},");
+        sb.AppendLine("\t\t\t},");
+        sb.AppendLine($"\t\t\tNumCoach\t\t\t\t\t=\t\t{package.Metadata.CoachCount},");
+        sb.AppendLine("\t\t\tMainCoach\t\t\t\t\t=\t\t-1,");
+        sb.AppendLine($"\t\t\tDifficulty\t\t\t\t\t=\t\t{package.Metadata.Difficulty},");
+        sb.AppendLine($"\t\t\tSweatDifficulty\t\t\t\t=\t\t{package.Metadata.SweatDifficulty},");
+        sb.AppendLine("\t\t\tTags =");
+        sb.AppendLine("\t\t\t{");
+        foreach (string tag in package.Metadata.Tags)
+            sb.AppendLine($"\t\t\t\t{{ VAL = \"{EscapeLuaString(tag)}\" }},");
+        sb.AppendLine("\t\t\t},");
+        sb.AppendLine($"\t\t\tStatus\t\t\t\t\t\t=\t\t{package.Metadata.Status.ToString(CultureInfo.InvariantCulture)},");
+        sb.AppendLine($"\t\t\tMojoValue\t\t\t\t\t=\t\t{package.Metadata.MojoValue},");
+        sb.AppendLine($"\t\t\tCountInProgression\t\t\t=\t\t{package.Metadata.CountInProgression},");
         sb.AppendLine("\t\t\t");
         sb.AppendLine("\t\t\t-- Game Modes");
         sb.AppendLine("\t\t\tGameModes = ");
@@ -87,8 +97,12 @@ public class UncookedEngineContentGenerator : IEngineContentGenerator
         sb.AppendLine("\t\t\t-- Default Colors");
         sb.AppendLine("\t\t\tDefaultColors = ");
         sb.AppendLine("\t\t\t{");
-        sb.AppendLine($"\t\t\t\t{{ KEY = \"lyrics\", VAL = \"{package.Metadata.LyricsColor}\" }},");
+        sb.AppendLine($"\t\t\t\t{{ KEY = \"lyrics\", VAL = \"{ToUbiArtColor(package.Metadata.LyricsColor)}\" }},");
         sb.AppendLine("\t\t\t\t{ KEY = \"theme\", VAL = \"0xffffffff\" },");
+        AppendSongColor(sb, package, "songcolor_1a", "songColor_1A");
+        AppendSongColor(sb, package, "songcolor_1b", "songColor_1B");
+        AppendSongColor(sb, package, "songcolor_2a", "songColor_2A");
+        AppendSongColor(sb, package, "songcolor_2b", "songColor_2B");
         sb.AppendLine("\t\t\t},");
         sb.AppendLine("\t\t\t");
         sb.AppendLine("\t\t\t-- Audio Previews\t\t\t");
@@ -133,7 +147,7 @@ public class UncookedEngineContentGenerator : IEngineContentGenerator
 
         // Build a MusicTrack template that includes an external .trk and references WAV
         StringBuilder sb = new();
-        sb.AppendLine($"includeReference(\"world/maps/{mapNameLower}/audio/{mapName}.trk\")");
+        sb.AppendLine($"includeReference(\"{GetMapRoot(mapNameLower)}/audio/{mapNameLower}.trk\")");
         sb.AppendLine();
         sb.AppendLine("params =");
         sb.AppendLine("{");
@@ -146,7 +160,7 @@ public class UncookedEngineContentGenerator : IEngineContentGenerator
         sb.AppendLine("\t\t\t\tNAME = \"MusicTrackComponent_Template\",");
         sb.AppendLine("\t\t\t\tMusicTrackComponent_Template =");
         sb.AppendLine("\t\t\t\t{");
-        sb.AppendLine("\t\t\t\t\ttrackData = { MusicTrackData = { path = \"world/maps/" + mapNameLower + "/audio/" + mapName + ".wav\", structure = structure, volume = 0 } },");
+        sb.AppendLine($"\t\t\t\t\ttrackData = {{ MusicTrackData = {{ path = \"{GetMapRoot(mapNameLower)}/audio/{mapNameLower}.wav\", structure = structure, volume = 0 }} }},");
         sb.AppendLine("\t\t\t\t}");
         sb.AppendLine("\t\t\t},");
         sb.AppendLine("\t\t}");
@@ -161,6 +175,7 @@ public class UncookedEngineContentGenerator : IEngineContentGenerator
         string mapNameLower = package.Metadata.MapName.ToLowerInvariant();
         List<object> allClips = [];
         List<object> tracks = [];
+        HashSet<long> moveTrackIds = [];
 
         // Add MotionClips for each coach
         foreach (MoveTimeline timeline in package.CoachTimelines)
@@ -177,26 +192,71 @@ public class UncookedEngineContentGenerator : IEngineContentGenerator
                     {
                         clip.Id,
                         timeline.TrackId,
+                        IsActive = 1,
                         clip.StartTime,
                         move.Duration,
-                        ClassifierPath = $"world/maps/{mapNameLower}/timeline/moves/{clip.MoveId}.msm",
+                        ClassifierPath = $"{GetMapRoot(mapNameLower)}/timeline/moves/{clip.MoveId}.msm",
                         GoldMove = clip.IsGoldMove ? 1 : 0,
                         timeline.CoachId,
+                        MoveType = 0,
                         Color = ParseColorToHex(move.Color)
                     }
                 });
             }
 
             // Add track for this coach
-            tracks.Add(new
+            if (moveTrackIds.Add(timeline.TrackId))
             {
-                NAME = "MoveTrack",
-                MoveTrack = new
+                tracks.Add(new
                 {
-                    Id = timeline.TrackId,
-                    Name = $"Coach{timeline.CoachId}"
-                }
-            });
+                    NAME = "MoveTrack",
+                    MoveTrack = new
+                    {
+                        Id = timeline.TrackId,
+                        Name = $"Coach{timeline.CoachId}"
+                    }
+                });
+            }
+        }
+
+        foreach (MoveTimeline timeline in package.FullBodyCoachTimelines)
+        {
+            foreach (MoveClip clip in timeline.Clips)
+            {
+                if (!package.FullBodyCoachMoves.TryGetValue(clip.MoveId, out CoachMoveDefinition? move))
+                    continue;
+
+                allClips.Add(new
+                {
+                    NAME = "MotionClip",
+                    MotionClip = new
+                    {
+                        clip.Id,
+                        timeline.TrackId,
+                        IsActive = 1,
+                        clip.StartTime,
+                        move.Duration,
+                        ClassifierPath = $"{GetMapRoot(mapNameLower)}/timeline/moves/{clip.MoveId}.gesture",
+                        GoldMove = clip.IsGoldMove ? 1 : 0,
+                        timeline.CoachId,
+                        MoveType = 1,
+                        Color = ParseColorToHex(move.Color)
+                    }
+                });
+            }
+
+            if (moveTrackIds.Add(timeline.TrackId))
+            {
+                tracks.Add(new
+                {
+                    NAME = "MoveTrack",
+                    MoveTrack = new
+                    {
+                        Id = timeline.TrackId,
+                        Name = $"Coach{timeline.CoachId}"
+                    }
+                });
+            }
         }
 
         // Add PictogramClips
@@ -211,7 +271,7 @@ public class UncookedEngineContentGenerator : IEngineContentGenerator
                     TrackId = PictoTrackId,
                     pictoClip.StartTime,
                     pictoClip.Duration,
-                    PictoPath = $"world/maps/{mapNameLower}/timeline/pictos/{pictoClip.PictogramId}.png",
+                    PictoPath = $"{GetMapRoot(mapNameLower)}/timeline/pictos/{pictoClip.PictogramId}{(version == UbiArtEngineVersion.JD2014 ? ".tga" : ".png")}",
                 }
             });
         }
@@ -331,7 +391,7 @@ public class UncookedEngineContentGenerator : IEngineContentGenerator
         sb.AppendLine("                    TapeEntry =");
         sb.AppendLine("                    {");
         sb.AppendLine($"                      Label = \"{tapeType}\",");
-        sb.AppendLine($"                      Path = \"world/maps/{mapNameLower}/timeline/{mapNameLower}_tml_{tapeType}.{extension}\",");
+        sb.AppendLine($"                      Path = \"{GetMapRoot(mapNameLower)}/timeline/{mapNameLower}_tml_{tapeType}.{extension}\",");
         sb.AppendLine("                    },");
         sb.AppendLine("                  },");
         sb.AppendLine("                },");
@@ -421,7 +481,7 @@ public class UncookedEngineContentGenerator : IEngineContentGenerator
         sb.AppendLine("                },");
         sb.AppendLine("                files =");
         sb.AppendLine("                {");
-        sb.AppendLine($"                  \"world/maps/{mapNameLower}/audio/amb/amb_{mapNameLower}_intro.wav\",");
+        sb.AppendLine($"                  \"{GetMapRoot(mapNameLower)}/audio/amb/amb_{mapNameLower}_intro.wav\",");
         sb.AppendLine("                },");
         sb.AppendLine("              },");
         sb.AppendLine("            },");
@@ -462,7 +522,7 @@ public class UncookedEngineContentGenerator : IEngineContentGenerator
         sb.AppendLine("                    TapeEntry =");
         sb.AppendLine("                    {");
         sb.AppendLine("                      Label = \"Master\",");
-        sb.AppendLine($"                      Path = \"world/maps/{mapNameLower}/cinematics/{mapNameLower}_mainsequence.tape\",");
+        sb.AppendLine($"                      Path = \"{GetMapRoot(mapNameLower)}/cinematics/{mapNameLower}_mainsequence.tape\",");
         sb.AppendLine("                    },");
         sb.AppendLine("                  },");
         sb.AppendLine("                },");
@@ -580,7 +640,7 @@ public class UncookedEngineContentGenerator : IEngineContentGenerator
                     IsActive = 1,
                     StartTime = startTime,
                     Duration = duration,
-                    SoundSetPath = $"world/maps/{mapNameLower}/audio/amb/amb_{mapNameLower}_intro.tpl"
+                    SoundSetPath = $"{GetMapRoot(mapNameLower)}/audio/amb/amb_{mapNameLower}_intro.tpl"
                 }
             });
 
@@ -622,22 +682,22 @@ public class UncookedEngineContentGenerator : IEngineContentGenerator
 <root>
 	<Scene ENGINE_VERSION=""55299"" GRIDUNIT=""0.500000"" DEPTH_SEPARATOR=""0"" NEAR_SEPARATOR=""1.000000 0.000000 0.000000 0.000000, 0.000000 1.000000 0.000000 0.000000, 0.000000 0.000000 1.000000 0.000000, 0.000000 0.000000 0.000000 1.000000"" FAR_SEPARATOR=""1.000000 0.000000 0.000000 0.000000, 0.000000 1.000000 0.000000 0.000000, 0.000000 0.000000 1.000000 0.000000, 0.000000 0.000000 0.000000 1.000000"">
 		<ACTORS NAME=""SubSceneActor"">
-			<SubSceneActor RELATIVEZ=""0.000000"" SCALE=""1.000000 1.000000"" xFLIPPED=""0"" USERFRIENDLY=""{mapName}_AUDIO"" MARKER="""" DEFAULTENABLE=""1"" POS2D=""0.000000 0.000000"" ANGLE=""0.000000"" INSTANCEDATAFILE=""enginedata/actortemplates/subscene.tpl"" LUA=""enginedata/actortemplates/subscene.tpl"" RELATIVEPATH=""world/maps/{mapNameLower}/audio/{mapNameLower}_audio.isc"" EMBED_SCENE=""0"" IS_SINGLE_PIECE=""0"" ZFORCED=""1"" DIRECT_PICKING=""1"">
+			<SubSceneActor RELATIVEZ=""0.000000"" SCALE=""1.000000 1.000000"" xFLIPPED=""0"" USERFRIENDLY=""{mapName}_AUDIO"" MARKER="""" DEFAULTENABLE=""1"" POS2D=""0.000000 0.000000"" ANGLE=""0.000000"" INSTANCEDATAFILE=""enginedata/actortemplates/subscene.tpl"" LUA=""enginedata/actortemplates/subscene.tpl"" RELATIVEPATH=""{GetMapRoot(mapNameLower)}/audio/{mapNameLower}_audio.isc"" EMBED_SCENE=""0"" IS_SINGLE_PIECE=""0"" ZFORCED=""1"" DIRECT_PICKING=""1"">
 				<ENUM NAME=""viewType"" SEL=""2"" />
 			</SubSceneActor>
 		</ACTORS>
 		<ACTORS NAME=""SubSceneActor"">
-			<SubSceneActor RELATIVEZ=""0.000000"" SCALE=""1.000000 1.000000"" xFLIPPED=""0"" USERFRIENDLY=""{mapName}_CINE"" MARKER="""" DEFAULTENABLE=""1"" POS2D=""0.000000 0.000000"" ANGLE=""0.000000"" INSTANCEDATAFILE=""enginedata/actortemplates/subscene.tpl"" LUA=""enginedata/actortemplates/subscene.tpl"" RELATIVEPATH=""world/maps/{mapNameLower}/cinematics/{mapNameLower}_cine.isc"" EMBED_SCENE=""0"" IS_SINGLE_PIECE=""0"" ZFORCED=""1"" DIRECT_PICKING=""1"">
+			<SubSceneActor RELATIVEZ=""0.000000"" SCALE=""1.000000 1.000000"" xFLIPPED=""0"" USERFRIENDLY=""{mapName}_CINE"" MARKER="""" DEFAULTENABLE=""1"" POS2D=""0.000000 0.000000"" ANGLE=""0.000000"" INSTANCEDATAFILE=""enginedata/actortemplates/subscene.tpl"" LUA=""enginedata/actortemplates/subscene.tpl"" RELATIVEPATH=""{GetMapRoot(mapNameLower)}/cinematics/{mapNameLower}_cine.isc"" EMBED_SCENE=""0"" IS_SINGLE_PIECE=""0"" ZFORCED=""1"" DIRECT_PICKING=""1"">
 				<ENUM NAME=""viewType"" SEL=""2"" />
 			</SubSceneActor>
 		</ACTORS>
 		<ACTORS NAME=""SubSceneActor"">
-			<SubSceneActor RELATIVEZ=""0.000000"" SCALE=""1.000000 1.000000"" xFLIPPED=""0"" USERFRIENDLY=""{mapName}_TML"" MARKER="""" DEFAULTENABLE=""1"" POS2D=""0.000000 0.000000"" ANGLE=""0.000000"" INSTANCEDATAFILE=""enginedata/actortemplates/subscene.tpl"" LUA=""enginedata/actortemplates/subscene.tpl"" RELATIVEPATH=""world/maps/{mapNameLower}/timeline/{mapNameLower}_tml.isc"" EMBED_SCENE=""0"" IS_SINGLE_PIECE=""0"" ZFORCED=""1"" DIRECT_PICKING=""1"">
+			<SubSceneActor RELATIVEZ=""0.000000"" SCALE=""1.000000 1.000000"" xFLIPPED=""0"" USERFRIENDLY=""{mapName}_TML"" MARKER="""" DEFAULTENABLE=""1"" POS2D=""0.000000 0.000000"" ANGLE=""0.000000"" INSTANCEDATAFILE=""enginedata/actortemplates/subscene.tpl"" LUA=""enginedata/actortemplates/subscene.tpl"" RELATIVEPATH=""{GetMapRoot(mapNameLower)}/timeline/{mapNameLower}_tml.isc"" EMBED_SCENE=""0"" IS_SINGLE_PIECE=""0"" ZFORCED=""1"" DIRECT_PICKING=""1"">
 				<ENUM NAME=""viewType"" SEL=""2"" />
 			</SubSceneActor>
 		</ACTORS>
 		<ACTORS NAME=""Actor"">
-			<Actor RELATIVEZ=""0.000000"" SCALE=""1.000000 1.000000"" xFLIPPED=""0"" USERFRIENDLY=""{mapName} : SongDesc"" POS2D=""0.000000 0.000000"" ANGLE=""0.000000"" INSTANCEDATAFILE="""" LUA=""world/maps/{mapNameLower}/songdesc.tpl"">
+			<Actor RELATIVEZ=""0.000000"" SCALE=""1.000000 1.000000"" xFLIPPED=""0"" USERFRIENDLY=""{mapName} : SongDesc"" POS2D=""0.000000 0.000000"" ANGLE=""0.000000"" INSTANCEDATAFILE="""" LUA=""{GetMapRoot(mapNameLower)}/songdesc.tpl"">
 				<COMPONENTS NAME=""JD_SongDescComponent"">
 					<JD_SongDescComponent />
 				</COMPONENTS>
@@ -668,7 +728,7 @@ public class UncookedEngineContentGenerator : IEngineContentGenerator
 <root>
 	<Scene ENGINE_VERSION=""55299"" GRIDUNIT=""0.500000"" DEPTH_SEPARATOR=""0"" NEAR_SEPARATOR=""1.000000 0.000000 0.000000 0.000000, 0.000000 1.000000 0.000000 0.000000, 0.000000 0.000000 1.000000 0.000000, 0.000000 0.000000 0.000000 1.000000"" FAR_SEPARATOR=""1.000000 0.000000 0.000000 0.000000, 0.000000 1.000000 0.000000 0.000000, 0.000000 0.000000 1.000000 0.000000, 0.000000 0.000000 0.000000 1.000000"">
 		<ACTORS NAME=""Actor"">
-			<Actor RELATIVEZ=""0.000000"" SCALE=""1.000000 1.000000"" xFLIPPED=""0"" USERFRIENDLY=""MusicTrack"" POS2D=""0.000000 0.000000"" ANGLE=""0.000000"" INSTANCEDATAFILE="""" LUA=""world/maps/{mapNameLower}/audio/{mapNameLower}_musictrack.tpl"">
+			<Actor RELATIVEZ=""0.000000"" SCALE=""1.000000 1.000000"" xFLIPPED=""0"" USERFRIENDLY=""MusicTrack"" POS2D=""0.000000 0.000000"" ANGLE=""0.000000"" INSTANCEDATAFILE="""" LUA=""{GetMapRoot(mapNameLower)}/audio/{mapNameLower}_musictrack.tpl"">
 				<COMPONENTS NAME=""MusicTrackComponent"">
 					<MusicTrackComponent />
 				</COMPONENTS>
@@ -692,14 +752,14 @@ public class UncookedEngineContentGenerator : IEngineContentGenerator
 <root>
 	<Scene ENGINE_VERSION=""55299"" GRIDUNIT=""0.500000"" DEPTH_SEPARATOR=""0"" NEAR_SEPARATOR=""1.000000 0.000000 0.000000 0.000000, 0.000000 1.000000 0.000000 0.000000, 0.000000 0.000000 1.000000 0.000000, 0.000000 0.000000 0.000000 1.000000"" FAR_SEPARATOR=""1.000000 0.000000 0.000000 0.000000, 0.000000 1.000000 0.000000 0.000000, 0.000000 0.000000 1.000000 0.000000, 0.000000 0.000000 0.000000 1.000000"">
 		<ACTORS NAME=""Actor"">
-			<Actor RELATIVEZ=""0.000000"" SCALE=""1.000000 1.000000"" xFLIPPED=""0"" USERFRIENDLY=""{mapName}_tml_dance"" POS2D=""0.000000 0.000000"" ANGLE=""0.000000"" INSTANCEDATAFILE=""{mapNameLower}_tml_dance.act"" LUA=""world/maps/{mapNameLower}/timeline/{mapNameLower}_tml_dance.tpl"">
+			<Actor RELATIVEZ=""0.000000"" SCALE=""1.000000 1.000000"" xFLIPPED=""0"" USERFRIENDLY=""{mapName}_tml_dance"" POS2D=""0.000000 0.000000"" ANGLE=""0.000000"" INSTANCEDATAFILE=""{mapNameLower}_tml_dance.act"" LUA=""{GetMapRoot(mapNameLower)}/timeline/{mapNameLower}_tml_dance.tpl"">
 				<COMPONENTS NAME=""TapeCase_Component"">
 					<TapeCase_Component />
 				</COMPONENTS>
 			</Actor>
 		</ACTORS>
 		<ACTORS NAME=""Actor"">
-			<Actor RELATIVEZ=""0.000000"" SCALE=""1.000000 1.000000"" xFLIPPED=""0"" USERFRIENDLY=""{mapName}_tml_karaoke"" POS2D=""0.000000 0.000000"" ANGLE=""0.000000"" INSTANCEDATAFILE=""{mapNameLower}_tml_karaoke.act"" LUA=""world/maps/{mapNameLower}/timeline/{mapNameLower}_tml_karaoke.tpl"">
+			<Actor RELATIVEZ=""0.000000"" SCALE=""1.000000 1.000000"" xFLIPPED=""0"" USERFRIENDLY=""{mapName}_tml_karaoke"" POS2D=""0.000000 0.000000"" ANGLE=""0.000000"" INSTANCEDATAFILE=""{mapNameLower}_tml_karaoke.act"" LUA=""{GetMapRoot(mapNameLower)}/timeline/{mapNameLower}_tml_karaoke.tpl"">
 				<COMPONENTS NAME=""TapeCase_Component"">
 					<TapeCase_Component />
 				</COMPONENTS>
@@ -723,7 +783,7 @@ public class UncookedEngineContentGenerator : IEngineContentGenerator
 <root>
 	<Scene ENGINE_VERSION=""55299"" GRIDUNIT=""0.500000"" DEPTH_SEPARATOR=""0"" NEAR_SEPARATOR=""1.000000 0.000000 0.000000 0.000000, 0.000000 1.000000 0.000000 0.000000, 0.000000 0.000000 1.000000 0.000000, 0.000000 0.000000 0.000000 1.000000"" FAR_SEPARATOR=""1.000000 0.000000 0.000000 0.000000, 0.000000 1.000000 0.000000 0.000000, 0.000000 0.000000 1.000000 0.000000, 0.000000 0.000000 0.000000 1.000000"">
 		<ACTORS NAME=""Actor"">
-			<Actor RELATIVEZ=""0.000000"" SCALE=""1.000000 1.000000"" xFLIPPED=""0"" USERFRIENDLY=""{mapName}_MainSequence"" POS2D=""0.000000 0.000000"" ANGLE=""0.000000"" INSTANCEDATAFILE=""world/maps/{mapNameLower}/cinematics/{mapNameLower}_mainsequence.act"" LUA=""world/maps/{mapNameLower}/cinematics/{mapNameLower}_mainsequence.tpl"">
+			<Actor RELATIVEZ=""0.000000"" SCALE=""1.000000 1.000000"" xFLIPPED=""0"" USERFRIENDLY=""{mapName}_MainSequence"" POS2D=""0.000000 0.000000"" ANGLE=""0.000000"" INSTANCEDATAFILE=""{GetMapRoot(mapNameLower)}/cinematics/{mapNameLower}_mainsequence.act"" LUA=""{GetMapRoot(mapNameLower)}/cinematics/{mapNameLower}_mainsequence.tpl"">
 				<COMPONENTS NAME=""MasterTape"">
 					<MasterTape bankState=""4294967295"" />
 				</COMPONENTS>
@@ -753,7 +813,7 @@ public class UncookedEngineContentGenerator : IEngineContentGenerator
 						<material>
 							<GFXMaterialSerializable>
 								<textureSet>
-									<GFXMaterialTexturePathSet diffuse=""world/maps/{mapNameLower}/menuart/textures/{mapNameLower}_cover_generic.tga"" />
+									<GFXMaterialTexturePathSet diffuse=""{GetMapRoot(mapNameLower)}/menuart/textures/{mapNameLower}_cover_generic.tga"" />
 								</textureSet>
 							</GFXMaterialSerializable>
 						</material>
@@ -768,7 +828,7 @@ public class UncookedEngineContentGenerator : IEngineContentGenerator
 						<material>
 							<GFXMaterialSerializable>
 								<textureSet>
-									<GFXMaterialTexturePathSet diffuse=""world/maps/{mapNameLower}/menuart/textures/{mapNameLower}_coach_1.tga"" />
+									<GFXMaterialTexturePathSet diffuse=""{GetMapRoot(mapNameLower)}/menuart/textures/{mapNameLower}_coach_1.tga"" />
 								</textureSet>
 							</GFXMaterialSerializable>
 						</material>
@@ -783,7 +843,7 @@ public class UncookedEngineContentGenerator : IEngineContentGenerator
 						<material>
 							<GFXMaterialSerializable>
 								<textureSet>
-									<GFXMaterialTexturePathSet diffuse=""world/maps/{mapNameLower}/menuart/textures/{mapNameLower}_map_bkg.tga"" />
+									<GFXMaterialTexturePathSet diffuse=""{GetMapRoot(mapNameLower)}/menuart/textures/{mapNameLower}_map_bkg.tga"" />
 								</textureSet>
 							</GFXMaterialSerializable>
 						</material>
@@ -809,7 +869,7 @@ public class UncookedEngineContentGenerator : IEngineContentGenerator
 <root>
 	<Scene ENGINE_VERSION=""55299"" GRIDUNIT=""0.500000"" DEPTH_SEPARATOR=""0"" NEAR_SEPARATOR=""1.000000 0.000000 0.000000 0.000000, 0.000000 1.000000 0.000000 0.000000, 0.000000 0.000000 1.000000 0.000000, 0.000000 0.000000 0.000000 1.000000"" FAR_SEPARATOR=""1.000000 0.000000 0.000000 0.000000, 0.000000 1.000000 0.000000 0.000000, 0.000000 0.000000 1.000000 0.000000, 0.000000 0.000000 0.000000 1.000000"">
 		<ACTORS NAME=""Actor"">
-			<Actor RELATIVEZ=""0.000000"" SCALE=""1.000000 1.000000"" xFLIPPED=""0"" USERFRIENDLY=""{mapName}_Autodance"" POS2D=""0.000000 0.000000"" ANGLE=""0.000000"" INSTANCEDATAFILE="""" LUA=""world/maps/{mapNameLower}/autodance/{mapNameLower}_autodance.tpl"">
+			<Actor RELATIVEZ=""0.000000"" SCALE=""1.000000 1.000000"" xFLIPPED=""0"" USERFRIENDLY=""{mapName}_Autodance"" POS2D=""0.000000 0.000000"" ANGLE=""0.000000"" INSTANCEDATAFILE="""" LUA=""{GetMapRoot(mapNameLower)}/autodance/{mapNameLower}_autodance.tpl"">
 				<COMPONENTS NAME=""JD_AutodanceComponent"">
 					<JD_AutodanceComponent />
 				</COMPONENTS>
@@ -878,9 +938,17 @@ public class UncookedEngineContentGenerator : IEngineContentGenerator
         sb.AppendLine("  NAME = \"Actor\",");
         sb.AppendLine("  Actor =");
         sb.AppendLine("  {");
-        sb.AppendLine($"    LUA = \"world/maps/{mapNameLower}/videoscoach/{mapNameLower}_video.tpl\",");
+        sb.AppendLine("    LUA = \"world/_common/videoscreen/video_player_main.tpl\",");
         sb.AppendLine("    COMPONENTS =");
         sb.AppendLine("    {");
+        sb.AppendLine("      {");
+        sb.AppendLine("        NAME = \"PleoComponent\",");
+        sb.AppendLine("        PleoComponent =");
+        sb.AppendLine("        {");
+        string videoFileName = string.IsNullOrWhiteSpace(VideoFileName) ? $"{mapNameLower}.webm" : VideoFileName;
+        sb.AppendLine($"          Video = \"{GetMapRoot(mapNameLower)}/videoscoach/{videoFileName}\",");
+        sb.AppendLine("        },");
+        sb.AppendLine("      },");
         sb.AppendLine("    },");
         sb.AppendLine("  },");
         sb.AppendLine("}");
@@ -902,7 +970,7 @@ public class UncookedEngineContentGenerator : IEngineContentGenerator
         sb.AppendLine("  NAME = \"Actor\",");
         sb.AppendLine("  Actor =");
         sb.AppendLine("  {");
-        sb.AppendLine($"    LUA = \"world/maps/{mapNameLower}/autodance/{mapNameLower}_autodance.tpl\",");
+        sb.AppendLine($"    LUA = \"{GetMapRoot(mapNameLower)}/autodance/{mapNameLower}_autodance.tpl\",");
         sb.AppendLine("    COMPONENTS =");
         sb.AppendLine("    {");
         sb.AppendLine("      {");
@@ -924,11 +992,27 @@ public class UncookedEngineContentGenerator : IEngineContentGenerator
         sb.AppendLine("  NAME = \"Actor\",");
         sb.AppendLine("  Actor =");
         sb.AppendLine("  {");
-        sb.AppendLine($"    LUA = \"world/maps/{mapNameLower}/menuart/actors/{textureName}.tpl\",");
+        sb.AppendLine("    LUA = \"enginedata/actortemplates/tpl_materialgraphiccomponent2d.tpl\",");
         sb.AppendLine("    COMPONENTS =");
         sb.AppendLine("    {");
         sb.AppendLine("      {");
         sb.AppendLine("        NAME = \"MaterialGraphicComponent\",");
+        sb.AppendLine("        MaterialGraphicComponent =");
+        sb.AppendLine("        {");
+        sb.AppendLine("          material =");
+        sb.AppendLine("          {");
+        sb.AppendLine("            GFXMaterialSerializable =");
+        sb.AppendLine("            {");
+        sb.AppendLine("              textureSet =");
+        sb.AppendLine("              {");
+        sb.AppendLine("                GFXMaterialTexturePathSet =");
+        sb.AppendLine("                {");
+        sb.AppendLine($"                  diffuse = \"{GetMapRoot(mapNameLower)}/menuart/textures/{textureName}.tga\",");
+        sb.AppendLine("                },");
+        sb.AppendLine("              },");
+        sb.AppendLine("            },");
+        sb.AppendLine("          },");
+        sb.AppendLine("        },");
         sb.AppendLine("      },");
         sb.AppendLine("    },");
         sb.AppendLine("  },");
@@ -950,14 +1034,33 @@ public class UncookedEngineContentGenerator : IEngineContentGenerator
             .Replace("\t", "\\t");
     }
 
+    private string GetMapRoot(string mapNameLower) => version switch
+    {
+        UbiArtEngineVersion.JD2014 => $"world/maps/jd5/{mapNameLower}",
+        UbiArtEngineVersion.JD2015 => $"world/maps/jd2015/{mapNameLower}",
+        _ => $"world/maps/{mapNameLower}"
+    };
+
     private static string ParseColorToHex(string hexColor)
     {
-        if (string.IsNullOrEmpty(hexColor) || hexColor.Length < 7)
-            return "0xFFFF8080";
+        return ToUbiArtColor(hexColor);
+    }
 
-        // Strip leading '#' and prepend with '0xFF'
-        string hex = hexColor.TrimStart('#');
-        return $"0xFF{hex}";
+    private static void AppendSongColor(StringBuilder builder, IntermediateSongPackage package, string metadataKey, string ubiArtKey)
+    {
+        if (package.Metadata.AdditionalMetadata.TryGetValue(metadataKey, out string? color) && !string.IsNullOrWhiteSpace(color))
+            builder.AppendLine($"\t\t\t\t{{ KEY = \"{ubiArtKey}\", VAL = \"{ToUbiArtColor(color)}\" }},");
+    }
+
+    private static string ToUbiArtColor(string color)
+    {
+        string hex = color.Trim().TrimStart('#');
+        return hex.Length switch
+        {
+            8 => $"0x{hex[6..8]}{hex[..6]}",
+            6 => $"0xFF{hex}",
+            _ => "0xFFFF8080"
+        };
     }
 
     private static int GetStartTime(object clip)

--- a/JustDanceEditor.Formats.UbiArt/Export/Generators/UncookedEngineContentGenerator.cs
+++ b/JustDanceEditor.Formats.UbiArt/Export/Generators/UncookedEngineContentGenerator.cs
@@ -4,7 +4,6 @@ using JustDanceEditor.Formats.UbiArt.Import;
 using JustDanceEditor.Formats.UbiArt.Serialization;
 
 using System.Reflection;
-using System.Globalization;
 using System.Text;
 
 namespace JustDanceEditor.Formats.UbiArt.Export.Generators;
@@ -27,147 +26,104 @@ public class UncookedEngineContentGenerator(UbiArtEngineVersion version = UbiArt
     public object GenerateSongDesc(IntermediateSongPackage package)
     {
         string mapName = package.Metadata.MapName;
-        string artist = EscapeLuaString(package.Metadata.Artist);
-        string title = EscapeLuaString(package.Metadata.Title);
         string mapNameLower = mapName.ToLowerInvariant();
         string mapRoot = GetMapRoot(mapNameLower);
+        List<object> phoneImages = [new { KEY = "cover", VAL = $"{mapRoot}/menuart/textures/{mapNameLower}_cover_phone.png" }];
+        phoneImages.AddRange(Enumerable.Range(1, package.Metadata.CoachCount)
+            .Select(index => (object)new { KEY = $"coach{index}", VAL = $"{mapRoot}/menuart/textures/{mapNameLower}_coach_{index}_phone.png" }));
 
-        StringBuilder sb = new();
-        sb.AppendLine("includeReference(\"EngineData/Helpers/SongDatabase.ilu\")");
-        sb.AppendLine();
-        sb.AppendLine("params =");
-        sb.AppendLine("{");
-        sb.AppendLine("  NAME = \"Actor_Template\",");
-        sb.AppendLine("  Actor_Template =");
-        sb.AppendLine("  {");
-        sb.AppendLine("\tTAGS =");
-        sb.AppendLine("\t{");
-        sb.AppendLine("\t\t{");
-        sb.AppendLine("\t\t\tVAL = \"songdescmain\",");
-        sb.AppendLine("\t\t},");
-        sb.AppendLine("\t},");
-        sb.AppendLine("    COMPONENTS =");
-        sb.AppendLine("    {");
-        sb.AppendLine("      {");
-        sb.AppendLine("        NAME=\"JD_SongDescTemplate\",");
-        sb.AppendLine("        JD_SongDescTemplate =");
-        sb.AppendLine("        {");
-        sb.AppendLine($"\t\t\tMapName\t\t\t\t\t\t=\t\t\"{mapName}\",");
-        sb.AppendLine($"\t\t\tJDVersion\t\t\t\t\t=\t\t{(int)version},");
-        sb.AppendLine($"\t\t\tOriginalJDVersion\t\t\t=\t\t{package.Metadata.OriginalJDVersion},");
-        sb.AppendLine("\t\t\tRelatedAlbums\t\t\t\t=\t\t");
-        sb.AppendLine("\t\t\t{");
-        sb.AppendLine("\t\t\t},");
-        sb.AppendLine($"\t\t\tArtist\t\t\t\t\t\t=\t\t\"{artist}\",");
-        sb.AppendLine($"\t\t\tTitle\t\t\t\t\t\t=\t\t\"{title}\",");
-        sb.AppendLine($"\t\t\tCredits\t\t\t\t\t\t=\t\t\"{EscapeLuaString(package.Metadata.Credits)}\",");
-        sb.AppendLine("\t\t\tPhoneImages =");
-        sb.AppendLine("\t\t\t{");
-        sb.AppendLine($"\t\t\t\t{{ KEY = \"cover\", VAL = \"{mapRoot}/menuart/textures/{mapNameLower}_cover_phone.png\" }},");
-        for (int coachIndex = 1; coachIndex <= package.Metadata.CoachCount; coachIndex++)
-            sb.AppendLine($"\t\t\t\t{{ KEY = \"coach{coachIndex}\", VAL = \"{mapRoot}/menuart/textures/{mapNameLower}_coach_{coachIndex}_phone.png\" }},");
-        sb.AppendLine("\t\t\t},");
-        sb.AppendLine($"\t\t\tNumCoach\t\t\t\t\t=\t\t{package.Metadata.CoachCount},");
-        sb.AppendLine("\t\t\tMainCoach\t\t\t\t\t=\t\t-1,");
-        sb.AppendLine($"\t\t\tDifficulty\t\t\t\t\t=\t\t{package.Metadata.Difficulty},");
-        sb.AppendLine($"\t\t\tSweatDifficulty\t\t\t\t=\t\t{package.Metadata.SweatDifficulty},");
-        sb.AppendLine("\t\t\tTags =");
-        sb.AppendLine("\t\t\t{");
-        foreach (string tag in package.Metadata.Tags)
-            sb.AppendLine($"\t\t\t\t{{ VAL = \"{EscapeLuaString(tag)}\" }},");
-        sb.AppendLine("\t\t\t},");
-        sb.AppendLine($"\t\t\tStatus\t\t\t\t\t\t=\t\t{package.Metadata.Status.ToString(CultureInfo.InvariantCulture)},");
-        sb.AppendLine($"\t\t\tMojoValue\t\t\t\t\t=\t\t{package.Metadata.MojoValue},");
-        sb.AppendLine($"\t\t\tCountInProgression\t\t\t=\t\t{package.Metadata.CountInProgression},");
-        sb.AppendLine("\t\t\t");
-        sb.AppendLine("\t\t\t-- Game Modes");
-        sb.AppendLine("\t\t\tGameModes = ");
-        sb.AppendLine("\t\t\t{");
-        sb.AppendLine("\t\t\t\t{");
-        sb.AppendLine("\t\t\t\t\tNAME = \"GameModeDesc\",");
-        sb.AppendLine("\t\t\t\t\tGameModeDesc = ");
-        sb.AppendLine("\t\t\t\t\t{");
-        sb.AppendLine("\t\t\t\t\t\tmode \t\t=\tGameMode.Classic,");
-        sb.AppendLine("\t\t\t\t\t\tflags\t\t=\tGameModeFlags.None,");
-        sb.AppendLine("\t\t\t\t\t\tstatus\t\t=\tGameModeStatus.Available,");
-        sb.AppendLine("\t\t\t\t\t},");
-        sb.AppendLine("\t\t\t\t},");
-        sb.AppendLine("\t\t\t},");
-        sb.AppendLine("\t\t\t");
-        sb.AppendLine("\t\t\t-- Default Colors");
-        sb.AppendLine("\t\t\tDefaultColors = ");
-        sb.AppendLine("\t\t\t{");
-        sb.AppendLine($"\t\t\t\t{{ KEY = \"lyrics\", VAL = \"{ToUbiArtColor(package.Metadata.LyricsColor)}\" }},");
-        sb.AppendLine("\t\t\t\t{ KEY = \"theme\", VAL = \"0xffffffff\" },");
-        AppendSongColor(sb, package, "songcolor_1a", "songColor_1A");
-        AppendSongColor(sb, package, "songcolor_1b", "songColor_1B");
-        AppendSongColor(sb, package, "songcolor_2a", "songColor_2A");
-        AppendSongColor(sb, package, "songcolor_2b", "songColor_2B");
-        sb.AppendLine("\t\t\t},");
-        sb.AppendLine("\t\t\t");
-        sb.AppendLine("\t\t\t-- Audio Previews\t\t\t");
-        sb.AppendLine("\t\t\tAudioPreviewFadeTime\t    =\t\t0.5,");
-        sb.AppendLine("\t\t\tAudioPreviews = ");
-        sb.AppendLine("\t\t\t{");
-        sb.AppendLine("\t\t\t\t{ ");
-        sb.AppendLine("\t\t\t\t\tNAME = \"AudioPreview\",");
-        sb.AppendLine("\t\t\t\t\tAudioPreview =");
-        sb.AppendLine("\t\t\t\t\t{ ");
-        sb.AppendLine("\t\t\t\t\t\tname \t\t= \t\"coverflow\",");
-        sb.AppendLine($"\t\t\t\t\t\tstartbeat\t=\t{package.TimelineStructure.PreviewEntryBeat}, ");
-        sb.AppendLine("\t\t\t\t\t\t-- endbeat\t=\t50,");
-        sb.AppendLine("\t\t\t\t\t},");
-        sb.AppendLine("\t\t\t\t},\t\t\t\t\t");
-        sb.AppendLine("\t\t\t\t");
-        sb.AppendLine("\t\t\t\t{ ");
-        sb.AppendLine("\t\t\t\t\tNAME = \"AudioPreview\",");
-        sb.AppendLine("\t\t\t\t\tAudioPreview =");
-        sb.AppendLine("\t\t\t\t\t{ ");
-        sb.AppendLine("\t\t\t\t\t\tname \t\t= \t\"prelobby\",");
-        sb.AppendLine($"\t\t\t\t\t\tstartbeat\t=\t{package.TimelineStructure.PreviewLoopStartBeat}, ");
-        sb.AppendLine($"\t\t\t\t\t\tendbeat\t=\t{package.TimelineStructure.PreviewLoopEndBeat},");
-        sb.AppendLine("\t\t\t\t\t},");
-        sb.AppendLine("\t\t\t\t},\t\t\t\t\t");
-        sb.AppendLine("\t\t\t},");
-        sb.AppendLine("\t\t\t");
-        sb.AppendLine("        },");
-        sb.AppendLine("      },");
-        sb.AppendLine("    },");
-        sb.AppendLine("  },");
-        sb.AppendLine("}");
-        sb.AppendLine();
+        List<object> defaultColors =
+        [
+            new { KEY = "lyrics", VAL = ToUbiArtColor(package.Metadata.LyricsColor) },
+            new { KEY = "theme", VAL = "0xffffffff" }
+        ];
+        AddSongColor(defaultColors, package, "songcolor_1a", "songColor_1A");
+        AddSongColor(defaultColors, package, "songcolor_1b", "songColor_1B");
+        AddSongColor(defaultColors, package, "songcolor_2a", "songColor_2A");
+        AddSongColor(defaultColors, package, "songcolor_2b", "songColor_2B");
 
-        return sb.ToString();
+        object songInfo = new
+        {
+            MapName = mapName,
+            JDVersion = (int)version,
+            package.Metadata.OriginalJDVersion,
+            RelatedAlbums = Array.Empty<object>(),
+            package.Metadata.Artist,
+            package.Metadata.Title,
+            package.Metadata.Credits,
+            PhoneImages = phoneImages,
+            NumCoach = package.Metadata.CoachCount,
+            MainCoach = -1,
+            package.Metadata.Difficulty,
+            package.Metadata.SweatDifficulty,
+            Tags = package.Metadata.Tags.Select(tag => new { VAL = tag }).ToArray(),
+            package.Metadata.Status,
+            package.Metadata.MojoValue,
+            package.Metadata.CountInProgression,
+            GameModes = new[]
+            {
+                new
+                {
+                    NAME = "GameModeDesc",
+                    GameModeDesc = new
+                    {
+                        mode = new LuaExpression("GameMode.Classic"),
+                        flags = new LuaExpression("GameModeFlags.None"),
+                        status = new LuaExpression("GameModeStatus.Available")
+                    }
+                }
+            },
+            DefaultColors = defaultColors,
+            AudioPreviewFadeTime = 0.5,
+            AudioPreviews = new object[]
+            {
+                new { NAME = "AudioPreview", AudioPreview = new { name = "coverflow", startbeat = package.TimelineStructure.PreviewEntryBeat } },
+                new { NAME = "AudioPreview", AudioPreview = new { name = "prelobby", startbeat = package.TimelineStructure.PreviewLoopStartBeat, endbeat = package.TimelineStructure.PreviewLoopEndBeat } }
+            }
+        };
+
+        object document = new
+        {
+            NAME = "Actor_Template",
+            Actor_Template = new
+            {
+                TAGS = new[] { new { VAL = "songdescmain" } },
+                COMPONENTS = new[] { new { NAME = "JD_SongDescTemplate", JD_SongDescTemplate = songInfo } }
+            }
+        };
+        return LuaDocumentWriter.Write(document, includes: ["EngineData/Helpers/SongDatabase.ilu"]);
     }
 
     public object GenerateMusicTrack(IntermediateSongPackage package)
     {
-        string mapName = package.Metadata.MapName;
-        string mapNameLower = mapName.ToLowerInvariant();
-
-        // Build a MusicTrack template that includes an external .trk and references WAV
-        StringBuilder sb = new();
-        sb.AppendLine($"includeReference(\"{GetMapRoot(mapNameLower)}/audio/{mapNameLower}.trk\")");
-        sb.AppendLine();
-        sb.AppendLine("params =");
-        sb.AppendLine("{");
-        sb.AppendLine("\tNAME = \"Actor_Template\",");
-        sb.AppendLine("\tActor_Template =");
-        sb.AppendLine("\t{");
-        sb.AppendLine("\t\tCOMPONENTS =");
-        sb.AppendLine("\t\t{");
-        sb.AppendLine("\t\t\t{");
-        sb.AppendLine("\t\t\t\tNAME = \"MusicTrackComponent_Template\",");
-        sb.AppendLine("\t\t\t\tMusicTrackComponent_Template =");
-        sb.AppendLine("\t\t\t\t{");
-        sb.AppendLine($"\t\t\t\t\ttrackData = {{ MusicTrackData = {{ path = \"{GetMapRoot(mapNameLower)}/audio/{mapNameLower}.wav\", structure = structure, volume = 0 }} }},");
-        sb.AppendLine("\t\t\t\t}");
-        sb.AppendLine("\t\t\t},");
-        sb.AppendLine("\t\t}");
-        sb.AppendLine("\t}");
-        sb.AppendLine("}");
-
-        return ToBytes(sb.ToString());
+        string mapNameLower = package.Metadata.MapName.ToLowerInvariant();
+        object document = new
+        {
+            NAME = "Actor_Template",
+            Actor_Template = new
+            {
+                COMPONENTS = new[]
+                {
+                    new
+                    {
+                        NAME = "MusicTrackComponent_Template",
+                        MusicTrackComponent_Template = new
+                        {
+                            trackData = new
+                            {
+                                MusicTrackData = new
+                                {
+                                    path = $"{GetMapRoot(mapNameLower)}/audio/{mapNameLower}.wav",
+                                    structure = new LuaExpression("structure"),
+                                    volume = 0
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        };
+        return Lua(document, includes: [$"{GetMapRoot(mapNameLower)}/audio/{mapNameLower}.trk"]);
     }
 
     public object GenerateDanceTape(IntermediateSongPackage package)
@@ -327,7 +283,7 @@ public class UncookedEngineContentGenerator(UbiArtEngineVersion version = UbiArt
             }
         };
 
-        return ToBytes(LuaTableSerializer.Serialize(danceTape));
+        return Lua(danceTape);
     }
 
     public object GenerateKaraokeTape(IntermediateSongPackage package)
@@ -360,7 +316,7 @@ public class UncookedEngineContentGenerator(UbiArtEngineVersion version = UbiArt
             }
         };
 
-        return ToBytes(LuaTableSerializer.Serialize(karaokeTape));
+        return Lua(karaokeTape);
     }
 
     public object GenerateTapeCaseTpl(string mapName, string tapeType)
@@ -368,66 +324,23 @@ public class UncookedEngineContentGenerator(UbiArtEngineVersion version = UbiArt
         string mapNameLower = mapName.ToLowerInvariant();
         string extension = tapeType == "dance" ? "dtape" : "ktape";
 
-        StringBuilder sb = new();
-        sb.AppendLine("params =");
-        sb.AppendLine("{");
-        sb.AppendLine("  NAME = \"Actor_Template\",");
-        sb.AppendLine("  Actor_Template =");
-        sb.AppendLine("  {");
-        sb.AppendLine("    COMPONENTS =");
-        sb.AppendLine("    {");
-        sb.AppendLine("      {");
-        sb.AppendLine("        NAME = \"TapeCase_Template\",");
-        sb.AppendLine("        TapeCase_Template =");
-        sb.AppendLine("        {");
-        sb.AppendLine("          TapesRack =");
-        sb.AppendLine("          {");
-        sb.AppendLine("            {");
-        sb.AppendLine("              TapeGroup =");
-        sb.AppendLine("              {");
-        sb.AppendLine("                Entries =");
-        sb.AppendLine("                {");
-        sb.AppendLine("                  {");
-        sb.AppendLine("                    TapeEntry =");
-        sb.AppendLine("                    {");
-        sb.AppendLine($"                      Label = \"{tapeType}\",");
-        sb.AppendLine($"                      Path = \"{GetMapRoot(mapNameLower)}/timeline/{mapNameLower}_tml_{tapeType}.{extension}\",");
-        sb.AppendLine("                    },");
-        sb.AppendLine("                  },");
-        sb.AppendLine("                },");
-        sb.AppendLine("              },");
-        sb.AppendLine("            },");
-        sb.AppendLine("          },");
-        sb.AppendLine("        },");
-        sb.AppendLine("      },");
-        sb.AppendLine("    },");
-        sb.AppendLine("  },");
-        sb.AppendLine("}");
-
-        return ToBytes(sb.ToString());
+        object entry = new
+        {
+            TapeEntry = new
+            {
+                Label = tapeType,
+                Path = $"{GetMapRoot(mapNameLower)}/timeline/{mapNameLower}_tml_{tapeType}.{extension}"
+            }
+        };
+        return Lua(ActorTemplate("TapeCase_Template", new
+        {
+            TapesRack = new[] { new { TapeGroup = new { Entries = new[] { entry } } } }
+        }));
     }
 
     public object GenerateSequenceTpl()
     {
-        StringBuilder sb = new();
-        sb.AppendLine("params =");
-        sb.AppendLine("{");
-        sb.AppendLine("  NAME = \"Actor_Template\",");
-        sb.AppendLine("  Actor_Template =");
-        sb.AppendLine("  {");
-        sb.AppendLine("    COMPONENTS =");
-        sb.AppendLine("    {");
-        sb.AppendLine("      {");
-        sb.AppendLine("        NAME = \"TapeCase_Template\",");
-        sb.AppendLine("        TapeCase_Template =");
-        sb.AppendLine("        {");
-        sb.AppendLine("        },");
-        sb.AppendLine("      },");
-        sb.AppendLine("    },");
-        sb.AppendLine("  },");
-        sb.AppendLine("}");
-
-        return ToBytes(sb.ToString());
+        return Lua(ActorTemplate("TapeCase_Template", new Dictionary<string, object?>()));
     }
 
     public object GenerateSoundTape(string mapName)
@@ -443,177 +356,74 @@ public class UncookedEngineContentGenerator(UbiArtEngineVersion version = UbiArt
             }
         };
 
-        return ToBytes(LuaTableSerializer.Serialize(stape));
+        return Lua(stape);
     }
 
     public object GenerateAmbTpl(string mapName)
     {
         string mapNameLower = mapName.ToLowerInvariant();
 
-        StringBuilder sb = new();
-        sb.AppendLine("params =");
-        sb.AppendLine("{");
-        sb.AppendLine("  NAME = \"Actor_Template\",");
-        sb.AppendLine("  Actor_Template =");
-        sb.AppendLine("  {");
-        sb.AppendLine("    COMPONENTS =");
-        sb.AppendLine("    {");
-        sb.AppendLine("      {");
-        sb.AppendLine("        NAME = \"SoundComponent_Template\",");
-        sb.AppendLine("        SoundComponent_Template =");
-        sb.AppendLine("        {");
-        sb.AppendLine("          soundList =");
-        sb.AppendLine("          {");
-        sb.AppendLine("            {");
-        sb.AppendLine("              SoundDescriptor_Template =");
-        sb.AppendLine("              {");
-        sb.AppendLine($"                name = \"amb_{mapNameLower}_intro\",");
-        sb.AppendLine("                volume = 6,");
-        sb.AppendLine("                category = \"amb\",");
-        sb.AppendLine("                limitMode = 0,");
-        sb.AppendLine("                params =");
-        sb.AppendLine("                {");
-        sb.AppendLine("                  SoundParams =");
-        sb.AppendLine("                  {");
-        sb.AppendLine("                    loop = 0,");
-        sb.AppendLine("                    playMode = 1,");
-        sb.AppendLine("                  },");
-        sb.AppendLine("                },");
-        sb.AppendLine("                files =");
-        sb.AppendLine("                {");
-        sb.AppendLine($"                  \"{GetMapRoot(mapNameLower)}/audio/amb/amb_{mapNameLower}_intro.wav\",");
-        sb.AppendLine("                },");
-        sb.AppendLine("              },");
-        sb.AppendLine("            },");
-        sb.AppendLine("          },");
-        sb.AppendLine("        },");
-        sb.AppendLine("      },");
-        sb.AppendLine("    },");
-        sb.AppendLine("  },");
-        sb.AppendLine("}");
-
-        return ToBytes(sb.ToString());
+        object descriptor = new
+        {
+            SoundDescriptor_Template = new
+            {
+                name = $"amb_{mapNameLower}_intro",
+                volume = 6,
+                category = "amb",
+                limitMode = 0,
+                @params = new { SoundParams = new { loop = 0, playMode = 1 } },
+                files = new[] { $"{GetMapRoot(mapNameLower)}/audio/amb/amb_{mapNameLower}_intro.wav" }
+            }
+        };
+        return Lua(ActorTemplate("SoundComponent_Template", new { soundList = new[] { descriptor } }));
     }
 
     public object GenerateMainSequenceTpl(string mapName)
     {
         string mapNameLower = mapName.ToLowerInvariant();
 
-        StringBuilder sb = new();
-        sb.AppendLine("params =");
-        sb.AppendLine("{");
-        sb.AppendLine("  NAME = \"Actor_Template\",");
-        sb.AppendLine("  Actor_Template =");
-        sb.AppendLine("  {");
-        sb.AppendLine("    COMPONENTS =");
-        sb.AppendLine("    {");
-        sb.AppendLine("      {");
-        sb.AppendLine("        NAME = \"MasterTape_Template\",");
-        sb.AppendLine("        MasterTape_Template =");
-        sb.AppendLine("        {");
-        sb.AppendLine("          TapesRack =");
-        sb.AppendLine("          {");
-        sb.AppendLine("            {");
-        sb.AppendLine("              TapeGroup =");
-        sb.AppendLine("              {");
-        sb.AppendLine("                Entries =");
-        sb.AppendLine("                {");
-        sb.AppendLine("                  {");
-        sb.AppendLine("                    TapeEntry =");
-        sb.AppendLine("                    {");
-        sb.AppendLine("                      Label = \"Master\",");
-        sb.AppendLine($"                      Path = \"{GetMapRoot(mapNameLower)}/cinematics/{mapNameLower}_mainsequence.tape\",");
-        sb.AppendLine("                    },");
-        sb.AppendLine("                  },");
-        sb.AppendLine("                },");
-        sb.AppendLine("              },");
-        sb.AppendLine("            },");
-        sb.AppendLine("          },");
-        sb.AppendLine("        },");
-        sb.AppendLine("      },");
-        sb.AppendLine("    },");
-        sb.AppendLine("  },");
-        sb.AppendLine("}");
-
-        return ToBytes(sb.ToString());
+        object entry = new
+        {
+            TapeEntry = new
+            {
+                Label = "Master",
+                Path = $"{GetMapRoot(mapNameLower)}/cinematics/{mapNameLower}_mainsequence.tape"
+            }
+        };
+        return Lua(ActorTemplate("MasterTape_Template", new
+        {
+            TapesRack = new[] { new { TapeGroup = new { Entries = new[] { entry } } } }
+        }));
     }
 
     public object GenerateSgs()
     {
-        StringBuilder sb = new();
-        sb.AppendLine("settings =");
-        sb.AppendLine("{");
-        sb.AppendLine("  JD_MapSceneConfig =");
-        sb.AppendLine("  {");
-        sb.AppendLine("    Pause_Level = 6,");
-        sb.AppendLine("    name = \"\",");
-        sb.AppendLine("    type = 1,");
-        sb.AppendLine("    musicscore = 2,");
-        sb.AppendLine("    soundContext = \"\",");
-        sb.AppendLine("    hud = 0,");
-        sb.AppendLine("  },");
-        sb.AppendLine("}");
-
-        return ToBytes(sb.ToString());
+        return Lua(new
+        {
+            JD_MapSceneConfig = new { Pause_Level = 6, name = "", type = 1, musicscore = 2, soundContext = "", hud = 0 }
+        }, assignment: "settings");
     }
 
     public object GenerateGenericActor(string className, string luaPath)
     {
-        StringBuilder sb = new();
-        sb.AppendLine("params =");
-        sb.AppendLine("{");
-        sb.AppendLine("  NAME = \"Actor\",");
-        sb.AppendLine("  Actor =");
-        sb.AppendLine("  {");
-        sb.AppendLine($"    LUA = \"{luaPath}\",");
-        sb.AppendLine("    COMPONENTS =");
-        sb.AppendLine("    {");
-        sb.AppendLine("      {");
-        sb.AppendLine($"        NAME = \"{className}\",");
-        sb.AppendLine("      },");
-        sb.AppendLine("    },");
-        sb.AppendLine("  },");
-        sb.AppendLine("}");
-
-        return ToBytes(sb.ToString());
+        return Lua(Actor(luaPath, new Dictionary<string, object?> { ["NAME"] = className }));
     }
 
     public object GenerateAutodanceTape(IntermediateSongPackage package)
     {
-        StringBuilder sb = new();
-        sb.AppendLine("params =");
-        sb.AppendLine("{");
-        sb.AppendLine("  NAME = \"Actor_Template\",");
-        sb.AppendLine("  Actor_Template =");
-        sb.AppendLine("  {");
-        sb.AppendLine("    COMPONENTS =");
-        sb.AppendLine("    {");
-        sb.AppendLine("      {");
-        sb.AppendLine("        NAME = \"JD_AutodanceComponent_Template\",");
-        sb.AppendLine("        JD_AutodanceComponent_Template =");
-        sb.AppendLine("        {");
-        sb.AppendLine($"          song = \"{package.Metadata.MapName}\",");
-        sb.AppendLine("          autodanceData =");
-        sb.AppendLine("          {");
-        sb.AppendLine("            JD_AutodanceData =");
-        sb.AppendLine("            {");
-        sb.AppendLine("              recording_structure =");
-        sb.AppendLine("              {");
-        sb.AppendLine("                JD_AutodanceRecordingStructure =");
-        sb.AppendLine("                {");
-        sb.AppendLine("                  records = {},");
-        sb.AppendLine("                },");
-        sb.AppendLine("              },");
-        sb.AppendLine("              playback_events = {},");
-        sb.AppendLine("            },");
-        sb.AppendLine("          },");
-        sb.AppendLine("        },");
-        sb.AppendLine("      },");
-        sb.AppendLine("    },");
-        sb.AppendLine("  },");
-        sb.AppendLine("}");
-
-        return ToBytes(sb.ToString());
+        object data = new
+        {
+            song = package.Metadata.MapName,
+            autodanceData = new
+            {
+                JD_AutodanceData = new
+                {
+                    recording_structure = new { JD_AutodanceRecordingStructure = new { records = Array.Empty<object>() } },
+                    playback_events = Array.Empty<object>()
+                }
+            }
+        };
+        return Lua(ActorTemplate("JD_AutodanceComponent_Template", data));
     }
 
     public object GenerateMainSequenceTape(IntermediateSongPackage package)
@@ -666,7 +476,7 @@ public class UncookedEngineContentGenerator(UbiArtEngineVersion version = UbiArt
             }
         };
 
-        return ToBytes(LuaTableSerializer.Serialize(tape));
+        return Lua(tape);
     }
 
     #endregion
@@ -678,69 +488,22 @@ public class UncookedEngineContentGenerator(UbiArtEngineVersion version = UbiArt
         string mapName = package.Metadata.MapName;
         string mapNameLower = mapName.ToLowerInvariant();
 
-        string content = $@"<?xml version=""1.0"" encoding=""ISO-8859-1""?>
-<root>
-	<Scene ENGINE_VERSION=""55299"" GRIDUNIT=""0.500000"" DEPTH_SEPARATOR=""0"" NEAR_SEPARATOR=""1.000000 0.000000 0.000000 0.000000, 0.000000 1.000000 0.000000 0.000000, 0.000000 0.000000 1.000000 0.000000, 0.000000 0.000000 0.000000 1.000000"" FAR_SEPARATOR=""1.000000 0.000000 0.000000 0.000000, 0.000000 1.000000 0.000000 0.000000, 0.000000 0.000000 1.000000 0.000000, 0.000000 0.000000 0.000000 1.000000"">
-		<ACTORS NAME=""SubSceneActor"">
-			<SubSceneActor RELATIVEZ=""0.000000"" SCALE=""1.000000 1.000000"" xFLIPPED=""0"" USERFRIENDLY=""{mapName}_AUDIO"" MARKER="""" DEFAULTENABLE=""1"" POS2D=""0.000000 0.000000"" ANGLE=""0.000000"" INSTANCEDATAFILE=""enginedata/actortemplates/subscene.tpl"" LUA=""enginedata/actortemplates/subscene.tpl"" RELATIVEPATH=""{GetMapRoot(mapNameLower)}/audio/{mapNameLower}_audio.isc"" EMBED_SCENE=""0"" IS_SINGLE_PIECE=""0"" ZFORCED=""1"" DIRECT_PICKING=""1"">
-				<ENUM NAME=""viewType"" SEL=""2"" />
-			</SubSceneActor>
-		</ACTORS>
-		<ACTORS NAME=""SubSceneActor"">
-			<SubSceneActor RELATIVEZ=""0.000000"" SCALE=""1.000000 1.000000"" xFLIPPED=""0"" USERFRIENDLY=""{mapName}_CINE"" MARKER="""" DEFAULTENABLE=""1"" POS2D=""0.000000 0.000000"" ANGLE=""0.000000"" INSTANCEDATAFILE=""enginedata/actortemplates/subscene.tpl"" LUA=""enginedata/actortemplates/subscene.tpl"" RELATIVEPATH=""{GetMapRoot(mapNameLower)}/cinematics/{mapNameLower}_cine.isc"" EMBED_SCENE=""0"" IS_SINGLE_PIECE=""0"" ZFORCED=""1"" DIRECT_PICKING=""1"">
-				<ENUM NAME=""viewType"" SEL=""2"" />
-			</SubSceneActor>
-		</ACTORS>
-		<ACTORS NAME=""SubSceneActor"">
-			<SubSceneActor RELATIVEZ=""0.000000"" SCALE=""1.000000 1.000000"" xFLIPPED=""0"" USERFRIENDLY=""{mapName}_TML"" MARKER="""" DEFAULTENABLE=""1"" POS2D=""0.000000 0.000000"" ANGLE=""0.000000"" INSTANCEDATAFILE=""enginedata/actortemplates/subscene.tpl"" LUA=""enginedata/actortemplates/subscene.tpl"" RELATIVEPATH=""{GetMapRoot(mapNameLower)}/timeline/{mapNameLower}_tml.isc"" EMBED_SCENE=""0"" IS_SINGLE_PIECE=""0"" ZFORCED=""1"" DIRECT_PICKING=""1"">
-				<ENUM NAME=""viewType"" SEL=""2"" />
-			</SubSceneActor>
-		</ACTORS>
-		<ACTORS NAME=""Actor"">
-			<Actor RELATIVEZ=""0.000000"" SCALE=""1.000000 1.000000"" xFLIPPED=""0"" USERFRIENDLY=""{mapName} : SongDesc"" POS2D=""0.000000 0.000000"" ANGLE=""0.000000"" INSTANCEDATAFILE="""" LUA=""{GetMapRoot(mapNameLower)}/songdesc.tpl"">
-				<COMPONENTS NAME=""JD_SongDescComponent"">
-					<JD_SongDescComponent />
-				</COMPONENTS>
-			</Actor>
-		</ACTORS>
-		<sceneConfigs>
-			<SceneConfigs activeSceneConfig=""0"">
-				<sceneConfigs NAME=""JD_MapSceneConfig"">
-					<JD_MapSceneConfig name="""" soundContext="""" hud=""0"">
-						<ENUM NAME=""Pause_Level"" SEL=""6"" />
-						<ENUM NAME=""type"" SEL=""1"" />
-						<ENUM NAME=""musicscore"" SEL=""2"" />
-					</JD_MapSceneConfig>
-				</sceneConfigs>
-			</SceneConfigs>
-		</sceneConfigs>
-	</Scene>
-</root>
-";
-        return ToBytes(content);
+        return Scene([
+            SubSceneActor($"{mapName}_AUDIO", $"{GetMapRoot(mapNameLower)}/audio/{mapNameLower}_audio.isc"),
+            SubSceneActor($"{mapName}_CINE", $"{GetMapRoot(mapNameLower)}/cinematics/{mapNameLower}_cine.isc"),
+            SubSceneActor($"{mapName}_TML", $"{GetMapRoot(mapNameLower)}/timeline/{mapNameLower}_tml.isc"),
+            SimpleSceneActor($"{mapName} : SongDesc", $"{GetMapRoot(mapNameLower)}/songdesc.tpl", "JD_SongDescComponent")
+        ], sceneConfig: MapSceneConfig());
     }
 
     public object GenerateAudioScene(IntermediateSongPackage package)
     {
         string mapNameLower = package.Metadata.MapName.ToLowerInvariant();
-
-        string content = $@"<?xml version=""1.0"" encoding=""ISO-8859-1""?>
-<root>
-	<Scene ENGINE_VERSION=""55299"" GRIDUNIT=""0.500000"" DEPTH_SEPARATOR=""0"" NEAR_SEPARATOR=""1.000000 0.000000 0.000000 0.000000, 0.000000 1.000000 0.000000 0.000000, 0.000000 0.000000 1.000000 0.000000, 0.000000 0.000000 0.000000 1.000000"" FAR_SEPARATOR=""1.000000 0.000000 0.000000 0.000000, 0.000000 1.000000 0.000000 0.000000, 0.000000 0.000000 1.000000 0.000000, 0.000000 0.000000 0.000000 1.000000"">
-		<ACTORS NAME=""Actor"">
-			<Actor RELATIVEZ=""0.000000"" SCALE=""1.000000 1.000000"" xFLIPPED=""0"" USERFRIENDLY=""MusicTrack"" POS2D=""0.000000 0.000000"" ANGLE=""0.000000"" INSTANCEDATAFILE="""" LUA=""{GetMapRoot(mapNameLower)}/audio/{mapNameLower}_musictrack.tpl"">
-				<COMPONENTS NAME=""MusicTrackComponent"">
-					<MusicTrackComponent />
-				</COMPONENTS>
-			</Actor>
-		</ACTORS>
-		<sceneConfigs>
-			<SceneConfigs activeSceneConfig=""0"" />
-		</sceneConfigs>
-	</Scene>
-</root>
-";
-        return ToBytes(content);
+        return Scene(
+            SimpleSceneActor(
+                "MusicTrack",
+                $"{GetMapRoot(mapNameLower)}/audio/{mapNameLower}_musictrack.tpl",
+                "MusicTrackComponent"));
     }
 
     public object GenerateTimelineScene(IntermediateSongPackage package)
@@ -748,30 +511,17 @@ public class UncookedEngineContentGenerator(UbiArtEngineVersion version = UbiArt
         string mapName = package.Metadata.MapName;
         string mapNameLower = mapName.ToLowerInvariant();
 
-        string content = $@"<?xml version=""1.0"" encoding=""ISO-8859-1""?>
-<root>
-	<Scene ENGINE_VERSION=""55299"" GRIDUNIT=""0.500000"" DEPTH_SEPARATOR=""0"" NEAR_SEPARATOR=""1.000000 0.000000 0.000000 0.000000, 0.000000 1.000000 0.000000 0.000000, 0.000000 0.000000 1.000000 0.000000, 0.000000 0.000000 0.000000 1.000000"" FAR_SEPARATOR=""1.000000 0.000000 0.000000 0.000000, 0.000000 1.000000 0.000000 0.000000, 0.000000 0.000000 1.000000 0.000000, 0.000000 0.000000 0.000000 1.000000"">
-		<ACTORS NAME=""Actor"">
-			<Actor RELATIVEZ=""0.000000"" SCALE=""1.000000 1.000000"" xFLIPPED=""0"" USERFRIENDLY=""{mapName}_tml_dance"" POS2D=""0.000000 0.000000"" ANGLE=""0.000000"" INSTANCEDATAFILE=""{mapNameLower}_tml_dance.act"" LUA=""{GetMapRoot(mapNameLower)}/timeline/{mapNameLower}_tml_dance.tpl"">
-				<COMPONENTS NAME=""TapeCase_Component"">
-					<TapeCase_Component />
-				</COMPONENTS>
-			</Actor>
-		</ACTORS>
-		<ACTORS NAME=""Actor"">
-			<Actor RELATIVEZ=""0.000000"" SCALE=""1.000000 1.000000"" xFLIPPED=""0"" USERFRIENDLY=""{mapName}_tml_karaoke"" POS2D=""0.000000 0.000000"" ANGLE=""0.000000"" INSTANCEDATAFILE=""{mapNameLower}_tml_karaoke.act"" LUA=""{GetMapRoot(mapNameLower)}/timeline/{mapNameLower}_tml_karaoke.tpl"">
-				<COMPONENTS NAME=""TapeCase_Component"">
-					<TapeCase_Component />
-				</COMPONENTS>
-			</Actor>
-		</ACTORS>
-		<sceneConfigs>
-			<SceneConfigs activeSceneConfig=""0"" />
-		</sceneConfigs>
-	</Scene>
-</root>
-";
-        return ToBytes(content);
+        return Scene(
+            SimpleSceneActor(
+                $"{mapName}_tml_dance",
+                $"{GetMapRoot(mapNameLower)}/timeline/{mapNameLower}_tml_dance.tpl",
+                "TapeCase_Component",
+                $"{mapNameLower}_tml_dance.act"),
+            SimpleSceneActor(
+                $"{mapName}_tml_karaoke",
+                $"{GetMapRoot(mapNameLower)}/timeline/{mapNameLower}_tml_karaoke.tpl",
+                "TapeCase_Component",
+                $"{mapNameLower}_tml_karaoke.act"));
     }
 
     public object GenerateCinematicsScene(IntermediateSongPackage package)
@@ -779,23 +529,16 @@ public class UncookedEngineContentGenerator(UbiArtEngineVersion version = UbiArt
         string mapName = package.Metadata.MapName;
         string mapNameLower = mapName.ToLowerInvariant();
 
-        string content = $@"<?xml version=""1.0"" encoding=""ISO-8859-1""?>
-<root>
-	<Scene ENGINE_VERSION=""55299"" GRIDUNIT=""0.500000"" DEPTH_SEPARATOR=""0"" NEAR_SEPARATOR=""1.000000 0.000000 0.000000 0.000000, 0.000000 1.000000 0.000000 0.000000, 0.000000 0.000000 1.000000 0.000000, 0.000000 0.000000 0.000000 1.000000"" FAR_SEPARATOR=""1.000000 0.000000 0.000000 0.000000, 0.000000 1.000000 0.000000 0.000000, 0.000000 0.000000 1.000000 0.000000, 0.000000 0.000000 0.000000 1.000000"">
-		<ACTORS NAME=""Actor"">
-			<Actor RELATIVEZ=""0.000000"" SCALE=""1.000000 1.000000"" xFLIPPED=""0"" USERFRIENDLY=""{mapName}_MainSequence"" POS2D=""0.000000 0.000000"" ANGLE=""0.000000"" INSTANCEDATAFILE=""{GetMapRoot(mapNameLower)}/cinematics/{mapNameLower}_mainsequence.act"" LUA=""{GetMapRoot(mapNameLower)}/cinematics/{mapNameLower}_mainsequence.tpl"">
-				<COMPONENTS NAME=""MasterTape"">
-					<MasterTape bankState=""4294967295"" />
-				</COMPONENTS>
-			</Actor>
-		</ACTORS>
-		<sceneConfigs>
-			<SceneConfigs activeSceneConfig=""0"" />
-		</sceneConfigs>
-	</Scene>
-</root>
-";
-        return ToBytes(content);
+        UbiArtXmlNode masterTape = UbiArtXmlDocumentWriter.Component(
+            "MasterTape",
+            UbiArtXmlDocumentWriter.Node("MasterTape", new { bankState = 4294967295u }));
+        return Scene(UbiArtXmlDocumentWriter.Actor(
+            "Actor",
+            UbiArtXmlDocumentWriter.StandardActorAttributes(
+                $"{mapName}_MainSequence",
+                $"{GetMapRoot(mapNameLower)}/cinematics/{mapNameLower}_mainsequence.tpl",
+                $"{GetMapRoot(mapNameLower)}/cinematics/{mapNameLower}_mainsequence.act"),
+            masterTape));
     }
 
     public object GenerateMenuArtScene(IntermediateSongPackage package)
@@ -803,61 +546,23 @@ public class UncookedEngineContentGenerator(UbiArtEngineVersion version = UbiArt
         string mapName = package.Metadata.MapName;
         string mapNameLower = mapName.ToLowerInvariant();
 
-        string content = $@"<?xml version=""1.0"" encoding=""ISO-8859-1""?>
-<root>
-	<Scene ENGINE_VERSION=""55299"" GRIDUNIT=""0.500000"" DEPTH_SEPARATOR=""0"" NEAR_SEPARATOR=""1.000000 0.000000 0.000000 0.000000, 0.000000 1.000000 0.000000 0.000000, 0.000000 0.000000 1.000000 0.000000, 0.000000 0.000000 0.000000 1.000000"" FAR_SEPARATOR=""1.000000 0.000000 0.000000 0.000000, 0.000000 1.000000 0.000000 0.000000, 0.000000 0.000000 1.000000 0.000000, 0.000000 0.000000 0.000000 1.000000"" viewFamily=""1"">
-		<ACTORS NAME=""Actor"">
-			<Actor RELATIVEZ=""0.000000"" SCALE=""0.3 0.3"" xFLIPPED=""0"" USERFRIENDLY=""{mapName}_cover_generic"" POS2D=""100.0 100.0"" ANGLE=""0.000000"" INSTANCEDATAFILE="""" LUA=""enginedata/actortemplates/tpl_materialgraphiccomponent2d.tpl"">
-				<COMPONENTS NAME=""MaterialGraphicComponent"">
-					<MaterialGraphicComponent>
-						<material>
-							<GFXMaterialSerializable>
-								<textureSet>
-									<GFXMaterialTexturePathSet diffuse=""{GetMapRoot(mapNameLower)}/menuart/textures/{mapNameLower}_cover_generic.tga"" />
-								</textureSet>
-							</GFXMaterialSerializable>
-						</material>
-					</MaterialGraphicComponent>
-				</COMPONENTS>
-			</Actor>
-		</ACTORS>
-		<ACTORS NAME=""Actor"">
-			<Actor RELATIVEZ=""0.000000"" SCALE=""0.3 0.3"" xFLIPPED=""0"" USERFRIENDLY=""{mapName}_coach_1"" POS2D=""400.0 100.0"" ANGLE=""0.000000"" INSTANCEDATAFILE="""" LUA=""enginedata/actortemplates/tpl_materialgraphiccomponent2d.tpl"">
-				<COMPONENTS NAME=""MaterialGraphicComponent"">
-					<MaterialGraphicComponent>
-						<material>
-							<GFXMaterialSerializable>
-								<textureSet>
-									<GFXMaterialTexturePathSet diffuse=""{GetMapRoot(mapNameLower)}/menuart/textures/{mapNameLower}_coach_1.tga"" />
-								</textureSet>
-							</GFXMaterialSerializable>
-						</material>
-					</MaterialGraphicComponent>
-				</COMPONENTS>
-			</Actor>
-		</ACTORS>
-		<ACTORS NAME=""Actor"">
-			<Actor RELATIVEZ=""0.000000"" SCALE=""0.5 0.25"" xFLIPPED=""0"" USERFRIENDLY=""{mapName}_map_bkg"" POS2D=""700.0 100.0"" ANGLE=""0.000000"" INSTANCEDATAFILE="""" LUA=""enginedata/actortemplates/tpl_materialgraphiccomponent2d.tpl"">
-				<COMPONENTS NAME=""MaterialGraphicComponent"">
-					<MaterialGraphicComponent>
-						<material>
-							<GFXMaterialSerializable>
-								<textureSet>
-									<GFXMaterialTexturePathSet diffuse=""{GetMapRoot(mapNameLower)}/menuart/textures/{mapNameLower}_map_bkg.tga"" />
-								</textureSet>
-							</GFXMaterialSerializable>
-						</material>
-					</MaterialGraphicComponent>
-				</COMPONENTS>
-			</Actor>
-		</ACTORS>
-		<sceneConfigs>
-			<SceneConfigs activeSceneConfig=""0"" />
-		</sceneConfigs>
-	</Scene>
-</root>
-";
-        return ToBytes(content);
+        return Scene([
+            MaterialSceneActor(
+                $"{mapName}_cover_generic",
+                $"{GetMapRoot(mapNameLower)}/menuart/textures/{mapNameLower}_cover_generic.tga",
+                "0.3 0.3",
+                "100.0 100.0"),
+            MaterialSceneActor(
+                $"{mapName}_coach_1",
+                $"{GetMapRoot(mapNameLower)}/menuart/textures/{mapNameLower}_coach_1.tga",
+                "0.3 0.3",
+                "400.0 100.0"),
+            MaterialSceneActor(
+                $"{mapName}_map_bkg",
+                $"{GetMapRoot(mapNameLower)}/menuart/textures/{mapNameLower}_map_bkg.tga",
+                "0.5 0.25",
+                "700.0 100.0")
+        ], viewFamily: true);
     }
 
     public object GenerateAutodanceScene(IntermediateSongPackage package)
@@ -865,57 +570,22 @@ public class UncookedEngineContentGenerator(UbiArtEngineVersion version = UbiArt
         string mapName = package.Metadata.MapName;
         string mapNameLower = mapName.ToLowerInvariant();
 
-        string content = $@"<?xml version=""1.0"" encoding=""ISO-8859-1""?>
-<root>
-	<Scene ENGINE_VERSION=""55299"" GRIDUNIT=""0.500000"" DEPTH_SEPARATOR=""0"" NEAR_SEPARATOR=""1.000000 0.000000 0.000000 0.000000, 0.000000 1.000000 0.000000 0.000000, 0.000000 0.000000 1.000000 0.000000, 0.000000 0.000000 0.000000 1.000000"" FAR_SEPARATOR=""1.000000 0.000000 0.000000 0.000000, 0.000000 1.000000 0.000000 0.000000, 0.000000 0.000000 1.000000 0.000000, 0.000000 0.000000 0.000000 1.000000"">
-		<ACTORS NAME=""Actor"">
-			<Actor RELATIVEZ=""0.000000"" SCALE=""1.000000 1.000000"" xFLIPPED=""0"" USERFRIENDLY=""{mapName}_Autodance"" POS2D=""0.000000 0.000000"" ANGLE=""0.000000"" INSTANCEDATAFILE="""" LUA=""{GetMapRoot(mapNameLower)}/autodance/{mapNameLower}_autodance.tpl"">
-				<COMPONENTS NAME=""JD_AutodanceComponent"">
-					<JD_AutodanceComponent />
-				</COMPONENTS>
-			</Actor>
-		</ACTORS>
-		<sceneConfigs>
-			<SceneConfigs activeSceneConfig=""0"" />
-		</sceneConfigs>
-	</Scene>
-</root>
-";
-        return ToBytes(content);
+        return Scene(SimpleSceneActor(
+            $"{mapName}_Autodance",
+            $"{GetMapRoot(mapNameLower)}/autodance/{mapNameLower}_autodance.tpl",
+            "JD_AutodanceComponent"));
     }
 
     public object GenerateGraphScene(string mapName)
     {
-        string content = $@"<?xml version=""1.0"" encoding=""ISO-8859-1""?>
-<root>
-	<Scene ENGINE_VERSION=""55299"" GRIDUNIT=""0.500000"" DEPTH_SEPARATOR=""0"" NEAR_SEPARATOR=""1.000000 0.000000 0.000000 0.000000, 0.000000 1.000000 0.000000 0.000000, 0.000000 0.000000 1.000000 0.000000, 0.000000 0.000000 0.000000 1.000000"" FAR_SEPARATOR=""1.000000 0.000000 0.000000 0.000000, 0.000000 1.000000 0.000000 0.000000, 0.000000 0.000000 1.000000 0.000000, 0.000000 0.000000 0.000000 1.000000"">
-		<sceneConfigs>
-			<SceneConfigs activeSceneConfig=""0"" />
-		</sceneConfigs>
-	</Scene>
-</root>
-";
-        return ToBytes(content);
+        return Scene();
     }
 
     public object GenerateVideoScene(string mapName)
     {
-        string mapNameLower = mapName.ToLowerInvariant();
-
-        string content = $@"<?xml version=""1.0"" encoding=""ISO-8859-1""?>
-<root>
-	<Scene ENGINE_VERSION=""55299"" GRIDUNIT=""0.500000"" DEPTH_SEPARATOR=""0"" NEAR_SEPARATOR=""1.000000 0.000000 0.000000 0.000000, 0.000000 1.000000 0.000000 0.000000, 0.000000 0.000000 1.000000 0.000000, 0.000000 0.000000 0.000000 1.000000"" FAR_SEPARATOR=""1.000000 0.000000 0.000000 0.000000, 0.000000 1.000000 0.000000 0.000000, 0.000000 0.000000 1.000000 0.000000, 0.000000 0.000000 0.000000 1.000000"">
-		<ACTORS NAME=""Actor"">
-			<Actor RELATIVEZ=""0.000000"" SCALE=""1.000000 1.000000"" xFLIPPED=""0"" USERFRIENDLY=""{mapName}_video"" POS2D=""0.000000 0.000000"" ANGLE=""0.000000"" INSTANCEDATAFILE=""video_player_main.act"">
-			</Actor>
-		</ACTORS>
-		<sceneConfigs>
-			<SceneConfigs activeSceneConfig=""0"" />
-		</sceneConfigs>
-	</Scene>
-</root>
-";
-        return ToBytes(content);
+        return Scene(UbiArtXmlDocumentWriter.Actor(
+            "Actor",
+            UbiArtXmlDocumentWriter.StandardActorAttributes($"{mapName}_video", "", "video_player_main.act")));
     }
 
     public object GenerateVideoMapPreviewScene(string mapName)
@@ -930,29 +600,11 @@ public class UncookedEngineContentGenerator(UbiArtEngineVersion version = UbiArt
 
     public object GenerateVideoPlayerActor(string mapName, bool isPreview)
     {
-        // Not typically needed for Uncooked - return empty actor
         string mapNameLower = mapName.ToLowerInvariant();
-        StringBuilder sb = new();
-        sb.AppendLine("params =");
-        sb.AppendLine("{");
-        sb.AppendLine("  NAME = \"Actor\",");
-        sb.AppendLine("  Actor =");
-        sb.AppendLine("  {");
-        sb.AppendLine("    LUA = \"world/_common/videoscreen/video_player_main.tpl\",");
-        sb.AppendLine("    COMPONENTS =");
-        sb.AppendLine("    {");
-        sb.AppendLine("      {");
-        sb.AppendLine("        NAME = \"PleoComponent\",");
-        sb.AppendLine("        PleoComponent =");
-        sb.AppendLine("        {");
         string videoFileName = string.IsNullOrWhiteSpace(VideoFileName) ? $"{mapNameLower}.webm" : VideoFileName;
-        sb.AppendLine($"          Video = \"{GetMapRoot(mapNameLower)}/videoscoach/{videoFileName}\",");
-        sb.AppendLine("        },");
-        sb.AppendLine("      },");
-        sb.AppendLine("    },");
-        sb.AppendLine("  },");
-        sb.AppendLine("}");
-        return ToBytes(sb.ToString());
+        return Lua(Actor(
+            "world/_common/videoscreen/video_player_main.tpl",
+            new { NAME = "PleoComponent", PleoComponent = new { Video = $"{GetMapRoot(mapNameLower)}/videoscoach/{videoFileName}" } }));
     }
 
     public object GenerateMpd()
@@ -964,75 +616,40 @@ public class UncookedEngineContentGenerator(UbiArtEngineVersion version = UbiArt
     public object GenerateAutodanceActor(string mapName)
     {
         string mapNameLower = mapName.ToLowerInvariant();
-        StringBuilder sb = new();
-        sb.AppendLine("params =");
-        sb.AppendLine("{");
-        sb.AppendLine("  NAME = \"Actor\",");
-        sb.AppendLine("  Actor =");
-        sb.AppendLine("  {");
-        sb.AppendLine($"    LUA = \"{GetMapRoot(mapNameLower)}/autodance/{mapNameLower}_autodance.tpl\",");
-        sb.AppendLine("    COMPONENTS =");
-        sb.AppendLine("    {");
-        sb.AppendLine("      {");
-        sb.AppendLine("        NAME = \"JD_AutodanceComponent\",");
-        sb.AppendLine("      },");
-        sb.AppendLine("    },");
-        sb.AppendLine("  },");
-        sb.AppendLine("}");
-        return ToBytes(sb.ToString());
+        return Lua(Actor(
+            $"{GetMapRoot(mapNameLower)}/autodance/{mapNameLower}_autodance.tpl",
+            new Dictionary<string, object?> { ["NAME"] = "JD_AutodanceComponent" }));
     }
 
     public object GenerateMenuArtActor(string textureName, string mapName)
     {
-        // Menu art actors are not typically needed for uncooked
         string mapNameLower = mapName.ToLowerInvariant();
-        StringBuilder sb = new();
-        sb.AppendLine("params =");
-        sb.AppendLine("{");
-        sb.AppendLine("  NAME = \"Actor\",");
-        sb.AppendLine("  Actor =");
-        sb.AppendLine("  {");
-        sb.AppendLine("    LUA = \"enginedata/actortemplates/tpl_materialgraphiccomponent2d.tpl\",");
-        sb.AppendLine("    COMPONENTS =");
-        sb.AppendLine("    {");
-        sb.AppendLine("      {");
-        sb.AppendLine("        NAME = \"MaterialGraphicComponent\",");
-        sb.AppendLine("        MaterialGraphicComponent =");
-        sb.AppendLine("        {");
-        sb.AppendLine("          material =");
-        sb.AppendLine("          {");
-        sb.AppendLine("            GFXMaterialSerializable =");
-        sb.AppendLine("            {");
-        sb.AppendLine("              textureSet =");
-        sb.AppendLine("              {");
-        sb.AppendLine("                GFXMaterialTexturePathSet =");
-        sb.AppendLine("                {");
-        sb.AppendLine($"                  diffuse = \"{GetMapRoot(mapNameLower)}/menuart/textures/{textureName}.tga\",");
-        sb.AppendLine("                },");
-        sb.AppendLine("              },");
-        sb.AppendLine("            },");
-        sb.AppendLine("          },");
-        sb.AppendLine("        },");
-        sb.AppendLine("      },");
-        sb.AppendLine("    },");
-        sb.AppendLine("  },");
-        sb.AppendLine("}");
-        return sb.ToString();
+        object component = new
+        {
+            NAME = "MaterialGraphicComponent",
+            MaterialGraphicComponent = new
+            {
+                material = new
+                {
+                    GFXMaterialSerializable = new
+                    {
+                        textureSet = new
+                        {
+                            GFXMaterialTexturePathSet = new
+                            {
+                                diffuse = $"{GetMapRoot(mapNameLower)}/menuart/textures/{textureName}.tga"
+                            }
+                        }
+                    }
+                }
+            }
+        };
+        return LuaDocumentWriter.Write(Actor("enginedata/actortemplates/tpl_materialgraphiccomponent2d.tpl", component));
     }
 
     #endregion
 
     #region Helper Methods
-
-    private static string EscapeLuaString(string value)
-    {
-        return value
-            .Replace("\\", "\\\\")
-            .Replace("\"", "\\\"")
-            .Replace("\n", "\\n")
-            .Replace("\r", "\\r")
-            .Replace("\t", "\\t");
-    }
 
     private string GetMapRoot(string mapNameLower) => version switch
     {
@@ -1046,10 +663,121 @@ public class UncookedEngineContentGenerator(UbiArtEngineVersion version = UbiArt
         return ToUbiArtColor(hexColor);
     }
 
-    private static void AppendSongColor(StringBuilder builder, IntermediateSongPackage package, string metadataKey, string ubiArtKey)
+    private static void AddSongColor(List<object> colors, IntermediateSongPackage package, string metadataKey, string ubiArtKey)
     {
         if (package.Metadata.AdditionalMetadata.TryGetValue(metadataKey, out string? color) && !string.IsNullOrWhiteSpace(color))
-            builder.AppendLine($"\t\t\t\t{{ KEY = \"{ubiArtKey}\", VAL = \"{ToUbiArtColor(color)}\" }},");
+            colors.Add(new { KEY = ubiArtKey, VAL = ToUbiArtColor(color) });
+    }
+
+    private static byte[] Lua(object value, string assignment = "params", IEnumerable<string>? includes = null) =>
+        ToBytes(LuaDocumentWriter.Write(value, assignment, includes));
+
+    private static object ActorTemplate(string componentName, object componentValue)
+    {
+        Dictionary<string, object?> component = new(StringComparer.Ordinal)
+        {
+            ["NAME"] = componentName,
+            [componentName] = componentValue
+        };
+        return new
+        {
+            NAME = "Actor_Template",
+            Actor_Template = new { COMPONENTS = new object[] { component } }
+        };
+    }
+
+    private static object Actor(string luaPath, params object[] components) => new
+    {
+        NAME = "Actor",
+        Actor = new { LUA = luaPath, COMPONENTS = components }
+    };
+
+    private static byte[] Scene(params UbiArtXmlNode[] actors) => Scene((IEnumerable<UbiArtXmlNode>)actors);
+
+    private static byte[] Scene(
+        IEnumerable<UbiArtXmlNode> actors,
+        bool viewFamily = false,
+        UbiArtXmlNode? sceneConfig = null)
+    {
+        List<UbiArtXmlNode> children = [.. actors];
+        children.Add(sceneConfig ?? UbiArtXmlDocumentWriter.DefaultSceneConfig());
+        return UbiArtXmlDocumentWriter.Write(UbiArtXmlDocumentWriter.Scene(children, viewFamily));
+    }
+
+    private static UbiArtXmlNode SimpleSceneActor(
+        string userFriendly,
+        string luaPath,
+        string componentName,
+        string instanceDataFile = "") =>
+        UbiArtXmlDocumentWriter.Actor(
+            "Actor",
+            UbiArtXmlDocumentWriter.StandardActorAttributes(userFriendly, luaPath, instanceDataFile),
+            UbiArtXmlDocumentWriter.Component(componentName));
+
+    private static UbiArtXmlNode SubSceneActor(string userFriendly, string relativePath) =>
+        UbiArtXmlDocumentWriter.Actor(
+            "SubSceneActor",
+            new
+            {
+                RELATIVEZ = "0.000000",
+                SCALE = "1.000000 1.000000",
+                xFLIPPED = 0,
+                USERFRIENDLY = userFriendly,
+                MARKER = "",
+                DEFAULTENABLE = 1,
+                POS2D = "0.000000 0.000000",
+                ANGLE = "0.000000",
+                INSTANCEDATAFILE = "enginedata/actortemplates/subscene.tpl",
+                LUA = "enginedata/actortemplates/subscene.tpl",
+                RELATIVEPATH = relativePath,
+                EMBED_SCENE = 0,
+                IS_SINGLE_PIECE = 0,
+                ZFORCED = 1,
+                DIRECT_PICKING = 1
+            },
+            UbiArtXmlDocumentWriter.Node("ENUM", new { NAME = "viewType", SEL = 2 }));
+
+    private static UbiArtXmlNode MaterialSceneActor(
+        string userFriendly,
+        string texturePath,
+        string scale,
+        string position)
+    {
+        UbiArtXmlNode material = UbiArtXmlDocumentWriter.Node(
+            "material",
+            null,
+            UbiArtXmlDocumentWriter.Node(
+                "GFXMaterialSerializable",
+                null,
+                UbiArtXmlDocumentWriter.Node(
+                    "textureSet",
+                    null,
+                    UbiArtXmlDocumentWriter.Node("GFXMaterialTexturePathSet", new { diffuse = texturePath }))));
+        return UbiArtXmlDocumentWriter.Actor(
+            "Actor",
+            UbiArtXmlDocumentWriter.StandardActorAttributes(
+                userFriendly,
+                "enginedata/actortemplates/tpl_materialgraphiccomponent2d.tpl",
+                scale: scale,
+                position: position),
+            UbiArtXmlDocumentWriter.Component("MaterialGraphicComponent", material));
+    }
+
+    private static UbiArtXmlNode MapSceneConfig()
+    {
+        UbiArtXmlNode config = UbiArtXmlDocumentWriter.Node(
+            "JD_MapSceneConfig",
+            new { name = "", soundContext = "", hud = 0 },
+            UbiArtXmlDocumentWriter.Node("ENUM", new { NAME = "Pause_Level", SEL = 6 }),
+            UbiArtXmlDocumentWriter.Node("ENUM", new { NAME = "type", SEL = 1 }),
+            UbiArtXmlDocumentWriter.Node("ENUM", new { NAME = "musicscore", SEL = 2 }));
+        return UbiArtXmlDocumentWriter.Node(
+            "sceneConfigs",
+            null,
+            UbiArtXmlDocumentWriter.Node(
+                "SceneConfigs",
+                new { activeSceneConfig = 0 },
+                UbiArtXmlDocumentWriter.Node("sceneConfigs", new { NAME = "JD_MapSceneConfig" }, config)));
     }
 
     private static string ToUbiArtColor(string color)

--- a/JustDanceEditor.Formats.UbiArt/Export/UbiArtAssetWriter.cs
+++ b/JustDanceEditor.Formats.UbiArt/Export/UbiArtAssetWriter.cs
@@ -6,6 +6,7 @@ using JustDanceEditor.Formats.UbiArt.Export.Generators;
 using JustDanceEditor.Formats.UbiArt.Export.Ipk;
 using JustDanceEditor.Formats.UbiArt.Import;
 using JustDanceEditor.Formats.UbiArt.Import.Layouts;
+using JustDanceEditor.Formats.UbiArt.Serialization;
 
 using KevInc.UbiArt.FileSystem;
 
@@ -13,9 +14,6 @@ using Microsoft.Extensions.Logging;
 
 using SixLabors.ImageSharp;
 using SixLabors.ImageSharp.PixelFormats;
-
-using System.Globalization;
-using System.Text;
 
 namespace JustDanceEditor.Formats.UbiArt.Export;
 
@@ -679,129 +677,89 @@ public sealed partial class UbiArtAssetWriter(ILogger<UbiArtAssetWriter> logger,
 
     private static async Task WriteUncookedTrkFileAsync(IntermediateSongPackage package, ExportContext ctx, string trkPath)
     {
-        StringBuilder trkBuilder = new();
-        trkBuilder.AppendLine("structure = { MusicTrackStructure = {");
-
-        // markers
-        trkBuilder.AppendLine("markers = {");
-        foreach (int m in package.TimelineStructure.Markers)
+        object structure = new
         {
-            trkBuilder.AppendLine($"    {{ VAL = {m} }},");
-        }
-
-        trkBuilder.AppendLine("},");
-
-        // signatures
-        trkBuilder.AppendLine("signatures = {");
-        foreach (SignatureSegment s in package.TimelineStructure.Signatures)
-        {
-            string comment = EscapeLuaString(s.Comment ?? string.Empty);
-            string markerStr = s.Marker.ToString(CultureInfo.InvariantCulture);
-            trkBuilder.AppendLine($"    {{ MusicSignature = {{ beats = {s.Beats}, marker = {markerStr}, comment = \"{comment}\" }} }},");
-        }
-
-        trkBuilder.AppendLine("},");
-
-        // sections
-        trkBuilder.AppendLine("sections = {");
-        foreach (SectionSegment sec in package.TimelineStructure.Sections)
-        {
-            string comment = EscapeLuaString(sec.Comment ?? string.Empty);
-            string markerStr = sec.StartBeat.ToString(CultureInfo.InvariantCulture);
-            trkBuilder.AppendLine($"    {{ MusicSection = {{ sectionType = {(int)sec.SectionType}, marker = {markerStr}, comment = \"{comment}\" }} }},");
-        }
-
-        trkBuilder.AppendLine("},");
-
-        // comments
-        trkBuilder.AppendLine("comments = {},");
-
-        // basic fields
-        trkBuilder.AppendLine($"startBeat = {package.TimelineStructure.StartBeat},");
-        trkBuilder.AppendLine($"endBeat = {package.TimelineStructure.EndBeat},");
-        trkBuilder.AppendLine($"videoStartTime = {package.TimelineStructure.VideoStartOffset.ToString(CultureInfo.InvariantCulture)},");
-        trkBuilder.AppendLine($"previewEntry = {package.TimelineStructure.PreviewEntryBeat},");
-        trkBuilder.AppendLine($"previewLoopStart = {package.TimelineStructure.PreviewLoopStartBeat},");
-        trkBuilder.AppendLine($"previewLoopEnd = {package.TimelineStructure.PreviewLoopEndBeat},");
-        trkBuilder.AppendLine($"previewDuration = {package.TimelineStructure.PreviewDuration},");
-
-        trkBuilder.AppendLine("} } ");
+            MusicTrackStructure = new
+            {
+                markers = package.TimelineStructure.Markers.Select(marker => new { VAL = marker }).ToArray(),
+                signatures = package.TimelineStructure.Signatures.Select(signature => new
+                {
+                    MusicSignature = new { beats = signature.Beats, marker = signature.Marker, comment = signature.Comment ?? string.Empty }
+                }).ToArray(),
+                sections = package.TimelineStructure.Sections.Select(section => new
+                {
+                    MusicSection = new { sectionType = (int)section.SectionType, marker = section.StartBeat, comment = section.Comment ?? string.Empty }
+                }).ToArray(),
+                comments = Array.Empty<object>(),
+                startBeat = package.TimelineStructure.StartBeat,
+                endBeat = package.TimelineStructure.EndBeat,
+                videoStartTime = package.TimelineStructure.VideoStartOffset,
+                previewEntry = package.TimelineStructure.PreviewEntryBeat,
+                previewLoopStart = package.TimelineStructure.PreviewLoopStartBeat,
+                previewLoopEnd = package.TimelineStructure.PreviewLoopEndBeat,
+                previewDuration = package.TimelineStructure.PreviewDuration
+            }
+        };
 
         string fullPath = ctx.IO.Combine(ctx.OutputFolder, trkPath);
         ctx.IO.CreateDirectory(Path.GetDirectoryName(fullPath) ?? throw new InvalidOperationException($"Could not determine the directory for '{fullPath}'."));
-        await File.WriteAllTextAsync(fullPath, trkBuilder.ToString());
+        await File.WriteAllTextAsync(fullPath, LuaDocumentWriter.Write(structure, assignment: "structure"));
     }
 
     private static async Task WriteUncookedAmbFilesAsync(IntermediateSongPackage package, ExportContext ctx, string ambFolder, string mapName)
     {
         string mapNameLower = mapName.ToLowerInvariant();
-        string audioWorldPath = $"world/maps/{mapNameLower}/audio/amb/amb_{mapName}_intro.wav";
-
-        // Write .ilu file
-        string iluContent = $@"DESCRIPTOR = 
-{{
-    {{
-		SoundDescriptor_Template=
-		{{
-			name=""amb_{mapName}_intro"",  
-			volume=-50,
-			category=""AMB"",
-			limitMode=LimiterMode.RejectNew,
-			params=
-			{{SoundParams={{
-				numChannels=2,
-				loop=0, 
-				playMode=PlayMode.Random,
-				randomVolMin=0.0,
-				randomVolMax=0.0,
-				randomPitchMin=1.0,
-				randomPitchMax=1.0,
-				fadeInTime=0.0,
-				fadeOutTime=0.0,
-			}}}},
-			files=
-			{{
-				{{
-					VAL=""{audioWorldPath}"",
-				}},
-			}},
-		}}
-	}},
-}}
-
-appendTable(component.SoundComponent_Template.soundList,DESCRIPTOR)";
+        string mapRoot = ctx.Layout.GetMapWorldFolder("", mapNameLower, UbiArtPlatform.Uncooked, ctx.EngineVersion).Replace('\\', '/');
+        string audioWorldPath = $"{mapRoot}/audio/amb/amb_{mapNameLower}_intro.wav";
+        object descriptor = new[]
+        {
+            new
+            {
+                SoundDescriptor_Template = new
+                {
+                    name = $"amb_{mapNameLower}_intro",
+                    volume = -50,
+                    category = "AMB",
+                    limitMode = new LuaExpression("LimiterMode.RejectNew"),
+                    @params = new
+                    {
+                        SoundParams = new
+                        {
+                            numChannels = 2,
+                            loop = 0,
+                            playMode = new LuaExpression("PlayMode.Random"),
+                            randomVolMin = 0.0,
+                            randomVolMax = 0.0,
+                            randomPitchMin = 1.0,
+                            randomPitchMax = 1.0,
+                            fadeInTime = 0.0,
+                            fadeOutTime = 0.0
+                        }
+                    },
+                    files = new[] { new { VAL = audioWorldPath } }
+                }
+            }
+        };
+        string iluContent = LuaDocumentWriter.Write(
+            descriptor,
+            assignment: "DESCRIPTOR",
+            trailingStatements: ["appendTable(component.SoundComponent_Template.soundList, DESCRIPTOR)"]);
 
         string iluPath = Path.Combine(ambFolder, $"AMB_{mapName}_Intro.ilu");
         string fullIluPath = ctx.IO.Combine(ctx.OutputFolder, iluPath);
         ctx.IO.CreateDirectory(Path.GetDirectoryName(fullIluPath) ?? throw new InvalidOperationException($"Could not determine the directory for '{fullIluPath}'."));
         await File.WriteAllTextAsync(fullIluPath, iluContent);
 
-        // Write .tpl file
-        string tplContent = $@"params=
-{{
-	NAME=""Actor_Template"",
-	Actor_Template=
-	{{
-		COMPONENTS=
-		{{
-		}}
-	}}
-}}
-includeReference(""world/maps/{mapNameLower}/audio/amb/amb_{mapName}_intro.wav"")
-";
+        object template = new
+        {
+            NAME = "Actor_Template",
+            Actor_Template = new { COMPONENTS = Array.Empty<object>() }
+        };
+        string tplContent = LuaDocumentWriter.Write(template, includes: [audioWorldPath]);
 
         string tplPath = Path.Combine(ambFolder, $"AMB_{mapName}_Intro.tpl");
         string fullTplPath = ctx.IO.Combine(ctx.OutputFolder, tplPath);
         await File.WriteAllTextAsync(fullTplPath, tplContent);
     }
 
-    private static string EscapeLuaString(string value)
-    {
-        return value
-            .Replace("\\", "\\\\")
-            .Replace("\"", "\\\"")
-            .Replace("\n", "\\n")
-            .Replace("\r", "\\r")
-            .Replace("\t", "\\t");
-    }
 }

--- a/JustDanceEditor.Formats.UbiArt/Export/UbiArtAssetWriter.cs
+++ b/JustDanceEditor.Formats.UbiArt/Export/UbiArtAssetWriter.cs
@@ -66,6 +66,18 @@ public sealed partial class UbiArtAssetWriter(ILogger<UbiArtAssetWriter> logger,
         string mapWorldBase = Path.Combine(platformRoot, mapWorldRelative);
         string rawMapWorldBase = layout.GetMapWorldFolder("", mapNameLower, platform, engineVersion);
 
+        if (platform == UbiArtPlatform.Uncooked &&
+            engineGenerator is UncookedEngineContentGenerator uncookedGenerator &&
+            !string.IsNullOrWhiteSpace(materializedRoot))
+        {
+            string videoSourceDir = iofs.Combine(materializedRoot, "assets", "video");
+            string? rawVideo = iofs.DirectoryExists(videoSourceDir)
+                ? FindRawVideoSource(iofs, videoSourceDir, mapNameLower)
+                : null;
+            if (rawVideo != null)
+                uncookedGenerator.VideoFileName = $"{mapNameLower}{Path.GetExtension(rawVideo).ToLowerInvariant()}";
+        }
+
         logger.LogInformation("Exporting {MapName} ({Platform}, {Version})...", mapName, platform, engineVersion);
 
         // 1. Generate Colors from Background
@@ -137,7 +149,7 @@ public sealed partial class UbiArtAssetWriter(ILogger<UbiArtAssetWriter> logger,
         // Check if using legacy binary format.
         bool isLegacyFormat = generator is LegacyEngineContentGenerator;
         bool useLegacyConvertedData = isLegacyFormat && version >= UbiArtEngineVersion.JD2016;
-        bool writeAutodanceResources = ShouldWriteAutodanceResources(platform, isLegacyFormat);
+        bool writeAutodanceResources = platform != UbiArtPlatform.Uncooked && ShouldWriteAutodanceResources(platform, isLegacyFormat);
         bool writeSoundSequence = version != UbiArtEngineVersion.JD2014 && ShouldWriteSoundSequence(package);
 
         List<Task> writeTasks = [];
@@ -186,10 +198,10 @@ public sealed partial class UbiArtAssetWriter(ILogger<UbiArtAssetWriter> logger,
         else
         {
             // Uncooked platform needs musictrack.tpl, .trk file, and AMB files
-            writeTasks.Add(exporter.WriteEngineResourceAsync(ctx, Path.Combine(audioFolder, $"{mapName}_musictrack.tpl"), generator.GenerateMusicTrack(package)));
+            writeTasks.Add(exporter.WriteEngineResourceAsync(ctx, Path.Combine(audioFolder, $"{mapNameLower}_musictrack.tpl"), generator.GenerateMusicTrack(package)));
 
             // Write .trk file with structure data
-            writeTasks.Add(WriteUncookedTrkFileAsync(package, ctx, Path.Combine(audioFolder, $"{mapName}.trk")));
+            writeTasks.Add(WriteUncookedTrkFileAsync(package, ctx, Path.Combine(audioFolder, $"{mapNameLower}.trk")));
 
             // Write AMB files if there's a negative start beat
             if (package.TimelineStructure.StartBeat < 0)
@@ -255,6 +267,11 @@ public sealed partial class UbiArtAssetWriter(ILogger<UbiArtAssetWriter> logger,
             if (writeAutodanceResources)
                 writeTasks.Add(exporter.WriteBinaryFileAsync(ctx, Path.Combine(autodanceFolder, $"{mapNameLower}_autodance.act"), generator.GenerateAutodanceActor(mapName)));
         }
+        else
+        {
+            writeTasks.Add(exporter.WriteEngineResourceAsync(ctx, Path.Combine(videosFolder, $"{mapNameLower}_video.isc"), generator.GenerateVideoScene(mapName)));
+            writeTasks.Add(exporter.WriteEngineResourceAsync(ctx, Path.Combine(videosFolder, "video_player_main.act"), generator.GenerateVideoPlayerActor(mapName, false)));
+        }
 
         await Task.WhenAll(writeTasks);
     }
@@ -313,6 +330,7 @@ public sealed partial class UbiArtAssetWriter(ILogger<UbiArtAssetWriter> logger,
         string menuRel = Path.Combine(mapWorldBase, "menuart", "textures");
         string actorsRel = Path.Combine(mapWorldBase, "menuart", "actors");
         bool isLegacyFormat = generator is LegacyEngineContentGenerator;
+        bool isUncooked = platform == UbiArtPlatform.Uncooked;
 
         // Create image service to access images at requested resolutions
         IntermediateImageService imageService = new(materializedRoot, package, ctx.IO);
@@ -335,32 +353,51 @@ public sealed partial class UbiArtAssetWriter(ILogger<UbiArtAssetWriter> logger,
         {
             using Image<Bgra32> coach = await imageService.GetCoachAsync(coachIndex, width: 1024, height: 1024, useFadeEffect: true, cancellationToken: cancellationToken);
             await WriteMenuArtTextureAsync($"{mapNameLower}_coach_{coachIndex}", coach, menuRel, actorsRel, ctx, exporter, generator, package, platform);
+
+            if (isUncooked)
+            {
+                using Image<Bgra32> phoneCoach = await imageService.GetCoachAsync(coachIndex, width: 256, height: 256, useFadeEffect: true, cancellationToken: cancellationToken);
+                await exporter.WriteTextureAsync(ctx, Path.Combine(menuRel, $"{mapNameLower}_coach_{coachIndex}_phone.png"), phoneCoach);
+            }
         });
 
         // 3. Cover Textures - all derived from square cover at different sizes
-        if (ShouldWriteMenuArtTexture($"{mapNameLower}_cover_generic", platform, version, isLegacyFormat))
+        if (isUncooked || ShouldWriteMenuArtTexture($"{mapNameLower}_cover_generic", platform, version, isLegacyFormat))
         {
-            using Image<Bgra32> coverGeneric = await imageService.GetSquareCoverAsync(width: 512, height: 512);
+            int coverSize = isUncooked ? 1024 : 512;
+            using Image<Bgra32> coverGeneric = await imageService.GetSquareCoverAsync(width: coverSize, height: coverSize);
             await WriteMenuArtTextureAsync($"{mapNameLower}_cover_generic", coverGeneric, menuRel, actorsRel, ctx, exporter, generator, package, platform);
         }
 
-        if (ShouldWriteMenuArtTexture($"{mapNameLower}_cover_online", platform, version, isLegacyFormat))
+        if (isUncooked || ShouldWriteMenuArtTexture($"{mapNameLower}_cover_online", platform, version, isLegacyFormat))
         {
             using Image<Bgra32> coverOnline = await imageService.GetSquareCoverAsync(width: 256, height: 256);
             await WriteMenuArtTextureAsync($"{mapNameLower}_cover_online", coverOnline, menuRel, actorsRel, ctx, exporter, generator, package, platform);
         }
 
-        if (ShouldWriteMenuArtTexture($"{mapNameLower}_cover_online_kids", platform, version, isLegacyFormat))
+        if (isUncooked || ShouldWriteMenuArtTexture($"{mapNameLower}_cover_online_kids", platform, version, isLegacyFormat))
         {
             using Image<Bgra32> coverKids = await imageService.GetSquareCoverAsync(width: 256, height: 256);
             await WriteMenuArtTextureAsync($"{mapNameLower}_cover_online_kids", coverKids, menuRel, actorsRel, ctx, exporter, generator, package, platform);
         }
 
+        if (isUncooked)
+        {
+            using Image<Bgra32> phoneCover = await imageService.GetSquareCoverAsync(width: 256, height: 256);
+            await exporter.WriteTextureAsync(ctx, Path.Combine(menuRel, $"{mapNameLower}_cover_phone.png"), phoneCover);
+        }
+
         // 4. Map Background (2048x1024)
-        if (ShouldWriteMenuArtTexture($"{mapNameLower}_map_bkg", platform, version, isLegacyFormat))
+        if (isUncooked || ShouldWriteMenuArtTexture($"{mapNameLower}_map_bkg", platform, version, isLegacyFormat))
         {
             using Image<Bgra32> mapBkg = await imageService.GetMapBackgroundAsync(width: 2048, height: 1024);
             await WriteMenuArtTextureAsync($"{mapNameLower}_map_bkg", mapBkg, menuRel, actorsRel, ctx, exporter, generator, package, platform);
+
+            if (isUncooked)
+            {
+                string graphTemplatePath = Path.Combine(platformRoot, "world", "_common", "graphic_component_templates", "graph", "textures", "background.png");
+                await exporter.WriteTextureAsync(ctx, graphTemplatePath, mapBkg);
+            }
         }
 
         // 5. Album Background (256x256 center-cropped square)
@@ -370,7 +407,7 @@ public sealed partial class UbiArtAssetWriter(ILogger<UbiArtAssetWriter> logger,
         }
 
         // 6. Banner (1024x512)
-        if (ShouldWriteMenuArtTexture($"{mapNameLower}_banner_bkg", platform, version, isLegacyFormat))
+        if (isUncooked || ShouldWriteMenuArtTexture($"{mapNameLower}_banner_bkg", platform, version, isLegacyFormat))
         {
             using Image<Bgra32> banner = await imageService.GetBannerAsync(width: 1024, height: 512);
             await WriteMenuArtTextureAsync($"{mapNameLower}_banner_bkg", banner, menuRel, actorsRel, ctx, exporter, generator, package, platform);
@@ -395,11 +432,11 @@ public sealed partial class UbiArtAssetWriter(ILogger<UbiArtAssetWriter> logger,
         // Write texture
         await exporter.WriteTextureAsync(ctx, Path.Combine(menuRel, $"{textureName}.tga"), image);
 
-        // Write actor (only for Cooked platforms)
-        if (platform != UbiArtPlatform.Uncooked)
-        {
-            await exporter.WriteBinaryFileAsync(ctx, Path.Combine(actorsRel, $"{textureName}.act"), generator.GenerateMenuArtActor(textureName, package.Metadata.MapName));
-        }
+        object actor = generator.GenerateMenuArtActor(textureName, package.Metadata.MapName);
+        if (platform == UbiArtPlatform.Uncooked)
+            await exporter.WriteEngineResourceAsync(ctx, Path.Combine(actorsRel, $"{textureName}.act"), actor);
+        else
+            await exporter.WriteBinaryFileAsync(ctx, Path.Combine(actorsRel, $"{textureName}.act"), actor);
     }
 
     private async Task GenerateColorsAsync(IntermediateSongPackage package, string materializedRoot, IFileSystem io)
@@ -483,10 +520,22 @@ public sealed partial class UbiArtAssetWriter(ILogger<UbiArtAssetWriter> logger,
         if (ctx.IO.DirectoryExists(videoSourceDir))
         {
             string mapNameLower = package.Metadata.MapName.ToLowerInvariant();
-            string destFileName = GetUbiArtVideoFileName(mapNameLower, platform, version);
-            JdiVideoEncodeRequest request = BuildUbiArtVideoRequest(materializedRoot, destFileName, platform, version);
+            string? sourceFile;
+            string destFileName;
 
-            string? sourceFile = await JdiVideoConverter.GetOrCreateVideoAsync(request, logger);
+            if (platform == UbiArtPlatform.Uncooked)
+            {
+                sourceFile = FindRawVideoSource(ctx.IO, videoSourceDir, mapNameLower);
+                destFileName = sourceFile == null
+                    ? $"{mapNameLower}.webm"
+                    : $"{mapNameLower}{Path.GetExtension(sourceFile).ToLowerInvariant()}";
+            }
+            else
+            {
+                destFileName = GetUbiArtVideoFileName(mapNameLower, platform, version);
+                JdiVideoEncodeRequest request = BuildUbiArtVideoRequest(materializedRoot, destFileName, platform, version);
+                sourceFile = await JdiVideoConverter.GetOrCreateVideoAsync(request, logger);
+            }
 
             if (sourceFile != null && ctx.IO.FileExists(sourceFile))
             {
@@ -497,11 +546,26 @@ public sealed partial class UbiArtAssetWriter(ILogger<UbiArtAssetWriter> logger,
                 ctx.IO.CreateDirectory(Path.GetDirectoryName(fullDest) ?? throw new InvalidOperationException($"Could not determine the directory for '{fullDest}'."));
                 ctx.IO.Copy(sourceFile, fullDest, true);
 
-                logger.LogInformation("Video exported to {Path} (Input: {Input})", destFileName, Path.GetFileName(sourceFile));
+                logger.LogInformation(
+                    platform == UbiArtPlatform.Uncooked
+                        ? "Video copied unchanged to {Path} (Input: {Input})"
+                        : "Video exported to {Path} (Input: {Input})",
+                    destFileName,
+                    Path.GetFileName(sourceFile));
             }
         }
 
-        CopyRawMoveAssets(materializedRoot, rawMapWorldBase, ctx, platform);
+        CopyRawMoveAssets(materializedRoot, rawMapWorldBase, ctx, platform, version);
+    }
+
+    private static string? FindRawVideoSource(IFileSystem io, string videoSourceDir, string mapNameLower)
+    {
+        string[] supportedExtensions = [".webm", ".mp4", ".mkv", ".avi", ".mov"];
+        return io.GetFiles(videoSourceDir)
+            .Where(file => supportedExtensions.Contains(Path.GetExtension(file), StringComparer.OrdinalIgnoreCase))
+            .OrderByDescending(file => Path.GetFileNameWithoutExtension(file).Equals(mapNameLower, StringComparison.OrdinalIgnoreCase))
+            .ThenBy(file => file, StringComparer.OrdinalIgnoreCase)
+            .FirstOrDefault();
     }
 
     private static JdiVideoEncodeRequest BuildUbiArtVideoRequest(string materializedRoot, string destFileName, UbiArtPlatform platform, UbiArtEngineVersion version)
@@ -546,11 +610,14 @@ public sealed partial class UbiArtAssetWriter(ILogger<UbiArtAssetWriter> logger,
             _ => $"{mapNameLower}.webm"
         };
 
-    private static void CopyRawMoveAssets(string materializedRoot, string rawMapWorldBase, ExportContext ctx, UbiArtPlatform platform)
+    private static void CopyRawMoveAssets(string materializedRoot, string rawMapWorldBase, ExportContext ctx, UbiArtPlatform platform, UbiArtEngineVersion version)
     {
-        string movesVersionFolder = ctx.EngineVersion == UbiArtEngineVersion.JD2014
-            ? IntermediatePackageLayout.Assets.MovesV5Folder
-            : IntermediatePackageLayout.Assets.MovesV7Folder;
+        string movesVersionFolder = version switch
+        {
+            UbiArtEngineVersion.JD2014 => IntermediatePackageLayout.Assets.MovesV5Folder,
+            UbiArtEngineVersion.JD2015 when platform == UbiArtPlatform.Uncooked => IntermediatePackageLayout.Assets.MovesV6Folder,
+            _ => IntermediatePackageLayout.Assets.MovesV7Folder
+        };
         string movesSource = ResolveMaterializedPath(ctx, materializedRoot, movesVersionFolder);
         if (ctx.IO.DirectoryExists(movesSource))
         {
@@ -558,13 +625,28 @@ public sealed partial class UbiArtAssetWriter(ILogger<UbiArtAssetWriter> logger,
             CopyRawFiles(ctx, movesSource, "*.msm", movesFolder);
         }
 
-        if (!UbiArtGestureFolders.TryGetPlatformFolder(platform, out string? gesturePlatformFolder) ||
-            gesturePlatformFolder == null)
+        string gesturesRoot = ResolveMaterializedPath(ctx, materializedRoot, IntermediatePackageLayout.Assets.GesturesFolder);
+        if (!ctx.IO.DirectoryExists(gesturesRoot))
             return;
 
-        string gesturesSource = ResolveMaterializedPath(ctx, materializedRoot, UbiArtGestureFolders.PackageFolder(gesturePlatformFolder));
-        if (ctx.IO.DirectoryExists(gesturesSource))
+        if (platform != UbiArtPlatform.Uncooked)
         {
+            if (UbiArtGestureFolders.TryGetPlatformFolder(platform, out string? platformFolder) && platformFolder != null)
+            {
+                string platformSource = ResolveMaterializedPath(ctx, materializedRoot, UbiArtGestureFolders.PackageFolder(platformFolder));
+                if (ctx.IO.DirectoryExists(platformSource))
+                    CopyRawFiles(ctx, platformSource, "*.gesture", Path.Combine(rawMapWorldBase, "timeline", "moves", platformFolder));
+            }
+
+            return;
+        }
+
+        foreach (string gesturesSource in ctx.IO.GetDirectories(gesturesRoot))
+        {
+            string gesturePlatformFolder = Path.GetFileName(gesturesSource.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar));
+            if (string.IsNullOrWhiteSpace(gesturePlatformFolder))
+                continue;
+
             string gesturesFolder = Path.Combine(rawMapWorldBase, "timeline", "moves", gesturePlatformFolder);
             CopyRawFiles(ctx, gesturesSource, "*.gesture", gesturesFolder);
         }

--- a/JustDanceEditor.Formats.UbiArt/Export/UbiArtExporterFactory.cs
+++ b/JustDanceEditor.Formats.UbiArt/Export/UbiArtExporterFactory.cs
@@ -27,10 +27,10 @@ public class UbiArtExporterFactory : IUbiArtExporterFactory
 
     public IEngineContentGenerator GetEngineContentGenerator(UbiArtEngineVersion version, UbiArtPlatform platform)
     {
-        // Uncooked platform always uses Lua format, regardless of engine version
+        // Uncooked exports use Lua, but paths and resource details still vary by engine version.
         if (platform == UbiArtPlatform.Uncooked)
         {
-            return new UncookedEngineContentGenerator();
+            return new UncookedEngineContentGenerator(version);
         }
 
         // JD2014/JD2015 cooked builds use binary engine resources on every cooked platform.

--- a/JustDanceEditor.Formats.UbiArt/FileSystem/JustDanceUbiArtFileSystem.cs
+++ b/JustDanceEditor.Formats.UbiArt/FileSystem/JustDanceUbiArtFileSystem.cs
@@ -192,6 +192,7 @@ public class JustDanceUbiArtFileSystem : IDisposable
     public bool GetFilePath(string relativeFilePath, [MaybeNullWhen(false)] out CookedFile filePath) => _fileSystem.GetFilePath(relativeFilePath, out filePath);
     public CookedFile GetFilePath(string relativeFilePath) => _fileSystem.GetFilePath(relativeFilePath);
     public CookedFile[] GetAllFiles(string relativeFolderPath, string pattern = "*") => _fileSystem.GetAllFiles(relativeFolderPath, pattern);
+    public string[] GetDirectories(string relativeFolderPath) => _fileSystem.GetInputDirectories(relativeFolderPath);
     public Stream GetFileStream(CookedFile cookedFile) => _fileSystem.GetFileStream(cookedFile);
     public bool GetFolderPath(string relativeFolderPath, [MaybeNullWhen(false)] out string folderPath) => _fileSystem.GetFolderPath(relativeFolderPath, out folderPath);
     public string GetFolderPath(string relativeFolderPath) => _fileSystem.GetFolderPath(relativeFolderPath);

--- a/JustDanceEditor.Formats.UbiArt/Import/Assets/FileSystemAssetResolver.cs
+++ b/JustDanceEditor.Formats.UbiArt/Import/Assets/FileSystemAssetResolver.cs
@@ -300,10 +300,18 @@ public class FileSystemAssetResolver(IUbiArtLayout layout, JustDanceUbiArtFileSy
     {
         string logicalName = GetLogicalMenuArtName(file);
 
-        return logicalName.Contains("_coach", StringComparison.OrdinalIgnoreCase) &&
+        return IsTextureExtension(file.Extension) &&
+            logicalName.Contains("_coach", StringComparison.OrdinalIgnoreCase) &&
             !logicalName.Contains("albumcoach", StringComparison.OrdinalIgnoreCase) &&
             !logicalName.Contains("phone", StringComparison.OrdinalIgnoreCase);
     }
+
+    private static bool IsTextureExtension(string extension) =>
+        extension.Equals(".png", StringComparison.OrdinalIgnoreCase) ||
+        extension.Equals(".tga", StringComparison.OrdinalIgnoreCase) ||
+        extension.Equals(".dds", StringComparison.OrdinalIgnoreCase) ||
+        extension.Equals(".jpg", StringComparison.OrdinalIgnoreCase) ||
+        extension.Equals(".jpeg", StringComparison.OrdinalIgnoreCase);
 
     private static string GetLogicalMenuArtName(CookedFile file)
     {

--- a/JustDanceEditor.Formats.UbiArt/Import/Audio/UbiArtAudioConverter.cs
+++ b/JustDanceEditor.Formats.UbiArt/Import/Audio/UbiArtAudioConverter.cs
@@ -385,7 +385,7 @@ public static class UbiArtAudioConverter
         List<ISampleProvider> sampleProviders = [];
 
         // Add main song with offset
-        float mainSongOffset = request.SongData.GetSongStartTime();
+        float mainSongOffset = request.SongData.GetAudioStartOffset();
         ISampleProvider mainSongProvider = mainSongStream.ToSampleProvider();
         WaveFormat mixFormat = mainSongProvider.WaveFormat;
         sampleProviders.Add(ApplyOffset(mainSongProvider, mainSongOffset));
@@ -498,7 +498,7 @@ public static class UbiArtAudioConverter
         if (markerIndex < 0)
             offset *= -1;
 
-        offset += request.SongData.GetSongStartTime();
+        offset += request.SongData.GetAudioStartOffset();
         return offset;
     }
 

--- a/JustDanceEditor.Formats.UbiArt/Import/Cinematics/Video/MashupTiming.cs
+++ b/JustDanceEditor.Formats.UbiArt/Import/Cinematics/Video/MashupTiming.cs
@@ -69,31 +69,7 @@ internal static class MashupTiming
         if (markers.Count < 2)
             return beat * 0.5;
 
-        int previousWholeBeat = (int)Math.Floor(beat);
-        int firstMarkerPosition = GetMusicTrackBeatSamplePosition(markers, previousWholeBeat);
-        int secondMarkerPosition = GetMusicTrackBeatSamplePosition(markers, previousWholeBeat + 1);
-        double beatFractionalPart = beat - previousWholeBeat;
-        double sampleOffset = firstMarkerPosition + (beatFractionalPart * (secondMarkerPosition - firstMarkerPosition));
-        return sampleOffset / 48000.0;
-    }
-
-    private static int GetMusicTrackBeatSamplePosition(IReadOnlyList<int> markers, int beat)
-    {
-        if (beat < 0)
-        {
-            int averageBeatLength = ComputeAverageMarkerSpacing(markers, 0, Math.Min(4, markers.Count - 1));
-            return beat * averageBeatLength;
-        }
-
-        if (beat >= markers.Count)
-        {
-            int endMarker = markers.Count - 1;
-            int startMarker = Math.Max(0, endMarker - 4);
-            int averageBeatLength = ComputeAverageMarkerSpacing(markers, startMarker, endMarker);
-            return markers[endMarker] + ((beat - markers.Count + 1) * averageBeatLength);
-        }
-
-        return markers[beat];
+        return MusicTrackTiming.GetSecondsAtBeat(markers, beat);
     }
 
     private static bool TryGetBlockNameBeat(string songName, out int beat)
@@ -105,13 +81,5 @@ internal static class MashupTiming
         string[] parts = songName.Split('_');
         return parts.Length > 1 &&
             int.TryParse(parts[^1], NumberStyles.Integer, CultureInfo.InvariantCulture, out beat);
-    }
-
-    private static int ComputeAverageMarkerSpacing(IReadOnlyList<int> markers, int startMarker, int endMarker)
-    {
-        if (endMarker <= startMarker)
-            return markers.Count >= 2 ? markers[1] - markers[0] : 24000;
-
-        return (markers[endMarker] - markers[startMarker]) / (endMarker - startMarker);
     }
 }

--- a/JustDanceEditor.Formats.UbiArt/Import/Intermediate/IntermediateAssetWriter.cs
+++ b/JustDanceEditor.Formats.UbiArt/Import/Intermediate/IntermediateAssetWriter.cs
@@ -439,8 +439,29 @@ internal static class IntermediateAssetWriter
     {
         string timelineMovesFolder = Path.Combine(context.FileSystem.InputFolders.TimelineFolder, "moves");
 
+        HashSet<string> seen = new(StringComparer.OrdinalIgnoreCase);
+        string[] directories;
+        try
+        {
+            directories = context.FileSystem.GetDirectories(timelineMovesFolder);
+        }
+        catch (DirectoryNotFoundException)
+        {
+            directories = [];
+        }
+
+        foreach (string directory in directories)
+        {
+            string platformFolder = Path.GetFileName(directory.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar));
+            if (!string.IsNullOrWhiteSpace(platformFolder) && seen.Add(platformFolder))
+                yield return new(Path.Combine(timelineMovesFolder, platformFolder), UbiArtGestureFolders.PackageFolder(platformFolder));
+        }
+
         foreach (UbiArtGestureFolder gestureFolder in UbiArtGestureFolders.All)
-            yield return new(Path.Combine(timelineMovesFolder, gestureFolder.PlatformFolder), gestureFolder.PackageRelativeFolder);
+        {
+            if (seen.Add(gestureFolder.PlatformFolder))
+                yield return new(Path.Combine(timelineMovesFolder, gestureFolder.PlatformFolder), gestureFolder.PackageRelativeFolder);
+        }
     }
 
     private static string? GetReferencedUbiArtGesturePackageFolder(ConversionContext context, string classifierPath)
@@ -461,6 +482,13 @@ internal static class IntermediateAssetWriter
             return false;
 
         string[] segments = relativePath.Split(['/', '\\'], StringSplitOptions.RemoveEmptyEntries);
+        int movesIndex = Array.FindIndex(segments, segment => segment.Equals("moves", StringComparison.OrdinalIgnoreCase));
+        if (movesIndex >= 0 && movesIndex + 1 < segments.Length)
+        {
+            packageFolder = UbiArtGestureFolders.PackageFolder(segments[movesIndex + 1]);
+            return true;
+        }
+
         foreach (UbiArtGestureFolder gestureFolder in UbiArtGestureFolders.All)
         {
             if (segments.Any(segment => segment.Equals(gestureFolder.PlatformFolder, StringComparison.OrdinalIgnoreCase)))

--- a/JustDanceEditor.Formats.UbiArt/Import/Intermediate/IntermediateAssetWriter.cs
+++ b/JustDanceEditor.Formats.UbiArt/Import/Intermediate/IntermediateAssetWriter.cs
@@ -857,44 +857,7 @@ internal static class IntermediateAssetWriter
         GetMusicTrackSecondsAtBeat(timelineStructure.Markers, beat) - timelineStructure.VideoStartOffset;
 
     private static double GetMusicTrackSecondsAtBeat(IReadOnlyList<int> markers, double beat)
-    {
-        if (markers.Count < 2)
-            throw new NotSupportedException("At least two markers are required for beat to seconds conversion.");
-
-        int previousWholeBeat = (int)Math.Floor(beat);
-        int firstMarkerPosition = GetMusicTrackBeatSamplePosition(markers, previousWholeBeat);
-        int secondMarkerPosition = GetMusicTrackBeatSamplePosition(markers, previousWholeBeat + 1);
-        double beatFractionalPart = beat - previousWholeBeat;
-        double sampleOffset = firstMarkerPosition + (beatFractionalPart * (secondMarkerPosition - firstMarkerPosition));
-        return sampleOffset / 48000.0;
-    }
-
-    private static int GetMusicTrackBeatSamplePosition(IReadOnlyList<int> markers, int beat)
-    {
-        if (beat < 0)
-        {
-            int averageBeatLength = ComputeAverageMarkerSpacing(markers, 0, Math.Min(4, markers.Count - 1));
-            return beat * averageBeatLength;
-        }
-
-        if (beat >= markers.Count)
-        {
-            int endMarker = markers.Count - 1;
-            int startMarker = Math.Max(0, endMarker - 4);
-            int averageBeatLength = ComputeAverageMarkerSpacing(markers, startMarker, endMarker);
-            return markers[endMarker] + ((beat - markers.Count + 1) * averageBeatLength);
-        }
-
-        return markers[beat];
-    }
-
-    private static int ComputeAverageMarkerSpacing(IReadOnlyList<int> markers, int startMarker, int endMarker)
-    {
-        if (endMarker <= startMarker)
-            return markers.Count >= 2 ? markers[1] - markers[0] : 24000;
-
-        return (markers[endMarker] - markers[startMarker]) / (endMarker - startMarker);
-    }
+        => MusicTrackTiming.GetSecondsAtBeat(markers, beat);
 
     private static int GetEffectiveEndBeat(TimelineStructureDocument timelineStructure)
     {

--- a/JustDanceEditor.Formats.UbiArt/Import/SongDataLoader.cs
+++ b/JustDanceEditor.Formats.UbiArt/Import/SongDataLoader.cs
@@ -11,6 +11,8 @@ using KevInc.UbiArt.FileSystem;
 
 using Microsoft.Extensions.Logging;
 
+using NLua.Exceptions;
+
 using System.Diagnostics.CodeAnalysis;
 using System.Text;
 using System.Text.Json;
@@ -181,23 +183,57 @@ public class SongDataLoader(ILogger<SongDataLoader> logger, JDI.Services.IFileSy
             // Prefer file type based on platform rather than file existence heuristics
             if (fileSystem.VersionProfile.Platform == UbiArtPlatform.Uncooked)
             {
-                // In Uncooked layout prefer .tpl first, then fallback to .dtape
+                CookedFile? resolvedDanceTape = null;
+                string resolvedDanceTapePath = danceTapeRelativePath;
+
                 if (fileSystem.GetFilePath(danceTplRelativePath, out CookedFile? danceTplPathCooked))
                 {
-                    _logger.LogInformation("Loading DanceTape from .tpl (Uncooked format)");
-                    using Stream danceTapeStream = fileSystem.GetFileStream(danceTplPathCooked);
-                    danceTape = DeserializeDanceTapeOrSkip(danceTapeStream, danceTplRelativePath);
+                    try
+                    {
+                        using Stream templateStream = fileSystem.GetFileStream(danceTplPathCooked);
+                        using StreamReader templateReader = new(templateStream, Encoding.UTF8);
+                        string templateContent = templateReader.ReadToEnd().TrimEnd('\0');
+                        string? referencedPath = LuaTableSerializer.DeserializeTapeEntryPaths(templateContent)
+                            .FirstOrDefault(path => Path.GetExtension(path).Equals(".dtape", StringComparison.OrdinalIgnoreCase));
+
+                        if (!string.IsNullOrWhiteSpace(referencedPath) &&
+                            fileSystem.GetFilePath(referencedPath, out CookedFile? referencedDanceTape))
+                        {
+                            resolvedDanceTape = referencedDanceTape;
+                            resolvedDanceTapePath = referencedPath;
+                        }
+                        else
+                        {
+                            _logger.LogWarning(
+                                "Dance TapeCase '{TemplatePath}' did not resolve an existing .dtape; falling back to '{FallbackPath}'.",
+                                danceTplRelativePath,
+                                danceTapeRelativePath);
+                        }
+                    }
+                    catch (Exception ex) when (ex is InvalidDataException or JsonException or IOException or LuaScriptException)
+                    {
+                        _logger.LogWarning(
+                            ex,
+                            "Could not resolve DanceTape from TapeCase '{TemplatePath}'; falling back to '{FallbackPath}'.",
+                            danceTplRelativePath,
+                            danceTapeRelativePath);
+                    }
                 }
-                else if (fileSystem.GetFilePath(danceTapeRelativePath, out CookedFile? danceDtapePathCooked))
+
+                if (resolvedDanceTape is null &&
+                    fileSystem.GetFilePath(danceTapeRelativePath, out CookedFile? fallbackDanceTape))
                 {
-                    _logger.LogInformation("DanceTape .tpl not found, falling back to .dtape");
-                    using Stream danceTapeStream = fileSystem.GetFileStream(danceDtapePathCooked);
-                    danceTape = DeserializeDanceTapeOrSkip(danceTapeStream, danceTapeRelativePath);
+                    resolvedDanceTape = fallbackDanceTape;
                 }
-                else
+
+                if (resolvedDanceTape is null)
                 {
                     throw new FileNotFoundException($"Dance tape not found at {danceTplRelativePath} or {danceTapeRelativePath}");
                 }
+
+                _logger.LogInformation("Loading DanceTape from '{DanceTapePath}' resolved through the uncooked TapeCase", resolvedDanceTapePath);
+                using Stream danceTapeStream = fileSystem.GetFileStream(resolvedDanceTape);
+                danceTape = DeserializeDanceTapeOrSkip(danceTapeStream, resolvedDanceTapePath);
             }
             else
             {

--- a/JustDanceEditor.Formats.UbiArt/Model/JDUbiArtSong.cs
+++ b/JustDanceEditor.Formats.UbiArt/Model/JDUbiArtSong.cs
@@ -13,17 +13,10 @@ public class JDUbiArtSong
     public LegacyMashupData? LegacyMashup { get; set; }
     public bool IsLegacyMashup => LegacyMashup != null;
 
-    public float GetSongStartTime()
+    public float GetAudioStartOffset()
     {
         Structure structure = MusicTrack.Components[0].TrackData.Structure;
-
-        int beat = structure.StartBeat;
-        int marker = Math.Abs(beat);
-        float time = structure.Markers[marker] / 48f / 1000f;
-
-        if (beat > 0)
-            time = -time;
-
-        return time;
+        int samplePosition = MusicTrackTiming.GetBeatSamplePosition(structure.Markers, structure.StartBeat);
+        return -samplePosition / (float)MusicTrackTiming.SampleRate;
     }
 }

--- a/JustDanceEditor.Formats.UbiArt/Model/JDUbiArtSong.cs
+++ b/JustDanceEditor.Formats.UbiArt/Model/JDUbiArtSong.cs
@@ -16,8 +16,6 @@ public class JDUbiArtSong
     public float GetSongStartTime()
     {
         Structure structure = MusicTrack.Components[0].TrackData.Structure;
-        if (Math.Abs(structure.VideoStartTime) > 0.000001f)
-            return -structure.VideoStartTime;
 
         int beat = structure.StartBeat;
         int marker = Math.Abs(beat);

--- a/JustDanceEditor.Formats.UbiArt/Model/MusicTrackTiming.cs
+++ b/JustDanceEditor.Formats.UbiArt/Model/MusicTrackTiming.cs
@@ -1,0 +1,47 @@
+namespace JustDanceEditor.Formats.UbiArt.Model;
+
+/// <summary>
+/// Implements UbiArt's MusicTrackStructure beat/sample conversions.
+/// </summary>
+internal static class MusicTrackTiming
+{
+    internal const int SampleRate = 48000;
+
+    internal static double GetSecondsAtBeat(IReadOnlyList<int> markers, double beat)
+    {
+        if (markers.Count < 2)
+            throw new NotSupportedException("At least two markers are required for beat to seconds conversion.");
+
+        int previousWholeBeat = (int)Math.Floor(beat);
+        int firstMarkerPosition = GetBeatSamplePosition(markers, previousWholeBeat);
+        int secondMarkerPosition = GetBeatSamplePosition(markers, previousWholeBeat + 1);
+        double beatFractionalPart = beat - previousWholeBeat;
+        double sampleOffset = firstMarkerPosition + (beatFractionalPart * (secondMarkerPosition - firstMarkerPosition));
+        return sampleOffset / SampleRate;
+    }
+
+    internal static int GetBeatSamplePosition(IReadOnlyList<int> markers, int beat)
+    {
+        if (markers.Count < 2)
+            throw new NotSupportedException("At least two markers are required for beat to sample conversion.");
+
+        if (beat < 0)
+        {
+            int averageBeatLength = ComputeAverageMarkerSpacing(markers, 0, Math.Min(4, markers.Count - 1));
+            return beat * averageBeatLength;
+        }
+
+        if (beat >= markers.Count)
+        {
+            int endMarker = markers.Count - 1;
+            int startMarker = Math.Max(0, endMarker - 4);
+            int averageBeatLength = ComputeAverageMarkerSpacing(markers, startMarker, endMarker);
+            return markers[endMarker] + ((beat - markers.Count + 1) * averageBeatLength);
+        }
+
+        return markers[beat];
+    }
+
+    private static int ComputeAverageMarkerSpacing(IReadOnlyList<int> markers, int startMarker, int endMarker) =>
+        (markers[endMarker] - markers[startMarker]) / (endMarker - startMarker);
+}

--- a/JustDanceEditor.Formats.UbiArt/Serialization/LuaDocumentWriter.cs
+++ b/JustDanceEditor.Formats.UbiArt/Serialization/LuaDocumentWriter.cs
@@ -1,0 +1,147 @@
+using System.Collections;
+using System.Globalization;
+using System.Reflection;
+using System.Text;
+
+namespace JustDanceEditor.Formats.UbiArt.Serialization;
+
+/// <summary>
+/// Serializes C# object graphs as UbiArt Lua data files.
+/// </summary>
+public static class LuaDocumentWriter
+{
+    public static string Write(
+        object? value,
+        string assignment = "params",
+        IEnumerable<string>? includes = null,
+        IEnumerable<string>? trailingStatements = null)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(assignment);
+
+        StringBuilder builder = new();
+        foreach (string include in includes ?? [])
+            builder.Append("includeReference(\"").Append(Escape(include)).AppendLine("\")");
+
+        if (builder.Length > 0)
+            builder.AppendLine();
+
+        builder.Append(assignment).AppendLine(" =");
+        WriteValue(builder, value, 0);
+        builder.AppendLine();
+        foreach (string statement in trailingStatements ?? [])
+            builder.AppendLine(statement);
+        return builder.ToString();
+    }
+
+    private static void WriteValue(StringBuilder builder, object? value, int depth)
+    {
+        switch (value)
+        {
+            case null:
+                builder.Append("nil");
+                return;
+            case LuaExpression expression:
+                builder.Append(expression.Value);
+                return;
+            case string text:
+                builder.Append('"').Append(Escape(text)).Append('"');
+                return;
+            case char character:
+                builder.Append('"').Append(Escape(character.ToString())).Append('"');
+                return;
+            case bool boolean:
+                builder.Append(boolean ? "true" : "false");
+                return;
+            case Enum enumValue:
+                builder.Append(Convert.ToInt64(enumValue, CultureInfo.InvariantCulture));
+                return;
+            case IFormattable formattable when IsNumber(value):
+                builder.Append(formattable.ToString(null, CultureInfo.InvariantCulture));
+                return;
+            case IDictionary dictionary:
+                WriteDictionary(builder, dictionary, depth);
+                return;
+            case IEnumerable sequence:
+                WriteSequence(builder, sequence, depth);
+                return;
+            default:
+                WriteProperties(builder, value, depth);
+                return;
+        }
+    }
+
+    private static void WriteDictionary(StringBuilder builder, IDictionary dictionary, int depth)
+    {
+        List<LuaField> fields = [];
+        IDictionaryEnumerator enumerator = dictionary.GetEnumerator();
+        while (enumerator.MoveNext())
+            fields.Add(new LuaField(FormatKey(enumerator.Key), enumerator.Value));
+        WriteTable(builder, fields, depth);
+    }
+
+    private static void WriteSequence(StringBuilder builder, IEnumerable sequence, int depth)
+    {
+        WriteTable(builder, sequence.Cast<object?>().Select(value => new LuaField(null, value)), depth);
+    }
+
+    private static void WriteProperties(StringBuilder builder, object value, int depth)
+    {
+        IEnumerable<LuaField> fields = value.GetType()
+            .GetProperties(BindingFlags.Instance | BindingFlags.Public)
+            .Where(property => property.CanRead && property.GetIndexParameters().Length == 0)
+            .Select(property => new LuaField(property.Name, property.GetValue(value)));
+        WriteTable(builder, fields, depth);
+    }
+
+    private static void WriteTable(StringBuilder builder, IEnumerable<LuaField> sourceFields, int depth)
+    {
+        LuaField[] fields = [.. sourceFields];
+        if (fields.Length == 0)
+        {
+            builder.Append("{}");
+            return;
+        }
+
+        builder.AppendLine("{");
+        foreach (LuaField field in fields)
+        {
+            builder.Append(' ', (depth + 1) * 2);
+            if (field.Key != null)
+                builder.Append(field.Key).Append(" = ");
+            WriteValue(builder, field.Value, depth + 1);
+            builder.AppendLine(",");
+        }
+
+        builder.Append(' ', depth * 2).Append('}');
+    }
+
+    private static string FormatKey(object? key)
+    {
+        string text = Convert.ToString(key, CultureInfo.InvariantCulture)
+            ?? throw new InvalidOperationException("Lua table keys cannot be null.");
+        return IsIdentifier(text) ? text : $"[\"{Escape(text)}\"]";
+    }
+
+    private static bool IsIdentifier(string value) =>
+        value.Length > 0 &&
+        (char.IsLetter(value[0]) || value[0] == '_') &&
+        value.Skip(1).All(character => char.IsLetterOrDigit(character) || character == '_');
+
+    private static bool IsNumber(object value) => value is
+        byte or sbyte or short or ushort or int or uint or long or ulong or
+        float or double or decimal;
+
+    private static string Escape(string value) => value
+        .Replace("\\", "\\\\", StringComparison.Ordinal)
+        .Replace("\"", "\\\"", StringComparison.Ordinal)
+        .Replace("\r", "\\r", StringComparison.Ordinal)
+        .Replace("\n", "\\n", StringComparison.Ordinal)
+        .Replace("\t", "\\t", StringComparison.Ordinal);
+
+    private readonly record struct LuaField(string? Key, object? Value);
+}
+
+/// <summary>
+/// A Lua expression that must be emitted without string quoting, such as an included table name.
+/// </summary>
+public readonly record struct LuaExpression(string Value);

--- a/JustDanceEditor.Formats.UbiArt/Serialization/LuaSongDescJsonConverters.cs
+++ b/JustDanceEditor.Formats.UbiArt/Serialization/LuaSongDescJsonConverters.cs
@@ -1,0 +1,126 @@
+using System.Globalization;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using System.Text.Json.Serialization;
+
+namespace JustDanceEditor.Formats.UbiArt.Serialization;
+
+internal static class LuaEntryTableJsonNormalizer
+{
+    public static JsonNode? Normalize(JsonElement element) => element.ValueKind switch
+    {
+        JsonValueKind.Object => NormalizeObject(element),
+        JsonValueKind.Array => NormalizeArray(element),
+        JsonValueKind.Null => null,
+        _ => JsonNode.Parse(element.GetRawText())
+    };
+
+    private static JsonObject NormalizeObject(JsonElement element)
+    {
+        JsonObject result = [];
+        foreach (JsonProperty property in element.EnumerateObject())
+            result[property.Name] = Normalize(property.Value);
+        return result;
+    }
+
+    private static JsonNode NormalizeArray(JsonElement element)
+    {
+        JsonElement[] entries = [.. element.EnumerateArray()];
+        if (entries.Length > 0 && entries.All(IsKeyValueEntry))
+        {
+            JsonObject result = [];
+            foreach (JsonElement entry in entries)
+            {
+                string key = entry.GetProperty("KEY").GetString() ?? string.Empty;
+                if (key.Length > 0)
+                    result[key] = Normalize(entry.GetProperty("VAL"));
+            }
+
+            return result;
+        }
+
+        JsonArray array = [];
+        bool isValueEntryArray = entries.Length > 0 && entries.All(IsValueEntry);
+        foreach (JsonElement entry in entries)
+            array.Add(Normalize(isValueEntryArray ? entry.GetProperty("VAL") : entry));
+        return array;
+    }
+
+    private static bool IsKeyValueEntry(JsonElement element) =>
+        element.ValueKind == JsonValueKind.Object &&
+        element.TryGetProperty("KEY", out _) &&
+        element.TryGetProperty("VAL", out _);
+
+    private static bool IsValueEntry(JsonElement element) =>
+        element.ValueKind == JsonValueKind.Object &&
+        element.TryGetProperty("VAL", out _) &&
+        element.EnumerateObject().All(property => property.NameEquals("VAL"));
+}
+
+internal static class ArgbColorJson
+{
+    public static bool TryReadHex(JsonElement element, out byte a, out byte r, out byte g, out byte b)
+    {
+        a = r = g = b = 0;
+        string? text = element.ValueKind == JsonValueKind.String ? element.GetString() : null;
+        if (text is null || !text.StartsWith("0x", StringComparison.OrdinalIgnoreCase) || text.Length != 10 ||
+            !uint.TryParse(text.AsSpan(2), NumberStyles.HexNumber, CultureInfo.InvariantCulture, out uint argb))
+        {
+            return false;
+        }
+
+        a = (byte)(argb >> 24);
+        r = (byte)(argb >> 16);
+        g = (byte)(argb >> 8);
+        b = (byte)argb;
+        return true;
+    }
+}
+
+internal sealed class ArgbFloatArrayJsonConverter : JsonConverter<float[]>
+{
+    public override float[] Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+    {
+        using JsonDocument document = JsonDocument.ParseValue(ref reader);
+        JsonElement element = document.RootElement;
+        if (ArgbColorJson.TryReadHex(element, out byte a, out byte r, out byte g, out byte b))
+            return [a / 255f, r / 255f, g / 255f, b / 255f];
+
+        if (element.ValueKind != JsonValueKind.Array)
+            throw new JsonException("Expected an ARGB string or numeric array.");
+
+        return [.. element.EnumerateArray().Select(component => component.GetSingle())];
+    }
+
+    public override void Write(Utf8JsonWriter writer, float[] value, JsonSerializerOptions options)
+    {
+        writer.WriteStartArray();
+        foreach (float component in value)
+            writer.WriteNumberValue(component);
+        writer.WriteEndArray();
+    }
+}
+
+internal sealed class ArgbIntArrayJsonConverter : JsonConverter<int[]>
+{
+    public override int[] Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+    {
+        using JsonDocument document = JsonDocument.ParseValue(ref reader);
+        JsonElement element = document.RootElement;
+        if (ArgbColorJson.TryReadHex(element, out byte a, out byte r, out byte g, out byte b))
+            return [a, r, g, b];
+
+        if (element.ValueKind != JsonValueKind.Array)
+            throw new JsonException("Expected an ARGB string or numeric array.");
+
+        return [.. element.EnumerateArray().Select(component => component.GetInt32())];
+    }
+
+    public override void Write(Utf8JsonWriter writer, int[] value, JsonSerializerOptions options)
+    {
+        writer.WriteStartArray();
+        foreach (int component in value)
+            writer.WriteNumberValue(component);
+        writer.WriteEndArray();
+    }
+}

--- a/JustDanceEditor.Formats.UbiArt/Serialization/LuaTableSerializer.cs
+++ b/JustDanceEditor.Formats.UbiArt/Serialization/LuaTableSerializer.cs
@@ -16,6 +16,16 @@ namespace JustDanceEditor.Formats.UbiArt.Serialization;
 
 public static partial class LuaTableSerializer
 {
+    private static readonly JsonSerializerOptions SongDescJsonOptions = CreateSongDescJsonOptions();
+
+    private static JsonSerializerOptions CreateSongDescJsonOptions()
+    {
+        JsonSerializerOptions options = new() { PropertyNameCaseInsensitive = true };
+        options.Converters.Add(new ArgbFloatArrayJsonConverter());
+        options.Converters.Add(new ArgbIntArrayJsonConverter());
+        return options;
+    }
+
     private static void InitializeLua(Lua lua)
     {
         lua.DoString("function includeReference(path) end");
@@ -88,6 +98,38 @@ public static partial class LuaTableSerializer
 
         return JsonSerializer.Deserialize<T>(json, new JsonSerializerOptions { PropertyNameCaseInsensitive = true })
             ?? throw new JsonException($"Failed to deserialize Lua content to {typeof(T).Name}.");
+    }
+
+    internal static IReadOnlyList<string> DeserializeTapeEntryPaths(string luaContent)
+    {
+        JsonElement root = Deserialize<JsonElement>(luaContent);
+        List<string> paths = [];
+        CollectTapeEntryPaths(root, paths, insideTapeEntry: false);
+        return paths;
+    }
+
+    private static void CollectTapeEntryPaths(JsonElement element, List<string> paths, bool insideTapeEntry)
+    {
+        if (element.ValueKind == JsonValueKind.Array)
+        {
+            foreach (JsonElement item in element.EnumerateArray())
+                CollectTapeEntryPaths(item, paths, insideTapeEntry);
+            return;
+        }
+
+        if (element.ValueKind != JsonValueKind.Object)
+            return;
+
+        if (insideTapeEntry &&
+            element.TryGetProperty("Path", out JsonElement pathElement) &&
+            pathElement.ValueKind == JsonValueKind.String &&
+            !string.IsNullOrWhiteSpace(pathElement.GetString()))
+        {
+            paths.Add(pathElement.GetString()!);
+        }
+
+        foreach (JsonProperty property in element.EnumerateObject())
+            CollectTapeEntryPaths(property.Value, paths, property.NameEquals("TapeEntry"));
     }
 
     public static T Deserialize<T>(string luaContent, JustDanceUbiArtFileSystem fileSystem) where T : new()
@@ -192,55 +234,10 @@ public static partial class LuaTableSerializer
                     {
                         if (prop.NameEquals("JD_SongDescTemplate"))
                         {
-                            // Create a copy of the component object without DefaultColors to avoid deserialization error
-                            Dictionary<string, object> dict = [];
-                            foreach (JsonProperty componentProp in prop.Value.EnumerateObject())
-                            {
-                                if (!componentProp.NameEquals("DefaultColors"))
-                                {
-                                    dict[componentProp.Name] = componentProp.Value;
-                                }
-                            }
-
-                            string sanitizedJson = JsonSerializer.Serialize(dict);
-                            InfoComponent info = JsonSerializer.Deserialize<InfoComponent>(sanitizedJson, new JsonSerializerOptions { PropertyNameCaseInsensitive = true })
+                            JsonNode normalizedComponent = LuaEntryTableJsonNormalizer.Normalize(prop.Value)
+                                ?? throw new JsonException("SongDesc component was null.");
+                            InfoComponent info = normalizedComponent.Deserialize<InfoComponent>(SongDescJsonOptions)
                                 ?? throw new JsonException("Failed to deserialize InfoComponent from Lua content.");
-
-                            // Manually map DefaultColors if it was an array
-                            if (prop.Value.TryGetProperty("DefaultColors", out JsonElement colors) && colors.ValueKind == JsonValueKind.Array)
-                            {
-                                foreach (JsonElement item in colors.EnumerateArray())
-                                {
-                                    if (item.TryGetProperty("KEY", out JsonElement key) && item.TryGetProperty("VAL", out JsonElement val))
-                                    {
-                                        string keyStr = key.GetString() ?? "";
-                                        string colorStr = val.GetString() ?? "";
-                                        if (colorStr.StartsWith("0x"))
-                                            colorStr = colorStr[2..];
-                                        if (colorStr.Length == 8)
-                                        {
-                                            float a = Convert.ToInt32(colorStr[..2], 16) / 255.0f;
-                                            float r = Convert.ToInt32(colorStr.Substring(2, 2), 16) / 255.0f;
-                                            float g = Convert.ToInt32(colorStr.Substring(4, 2), 16) / 255.0f;
-                                            float b = Convert.ToInt32(colorStr.Substring(6, 2), 16) / 255.0f;
-                                            float[] rgba = [a, r, g, b];
-
-                                            if (keyStr.Equals("lyrics", StringComparison.OrdinalIgnoreCase))
-                                                info.DefaultColors.Lyrics = rgba;
-                                            else if (keyStr.Equals("theme", StringComparison.OrdinalIgnoreCase))
-                                                info.DefaultColors.Theme = Array.ConvertAll(rgba, v => (int)(v * 255));
-                                            else if (keyStr.Equals("songcolor_1a", StringComparison.OrdinalIgnoreCase))
-                                                info.DefaultColors.SongColor1a = rgba;
-                                            else if (keyStr.Equals("songcolor_1b", StringComparison.OrdinalIgnoreCase))
-                                                info.DefaultColors.SongColor1b = rgba;
-                                            else if (keyStr.Equals("songcolor_2a", StringComparison.OrdinalIgnoreCase))
-                                                info.DefaultColors.SongColor2a = rgba;
-                                            else if (keyStr.Equals("songcolor_2b", StringComparison.OrdinalIgnoreCase))
-                                                info.DefaultColors.SongColor2b = rgba;
-                                        }
-                                    }
-                                }
-                            }
 
                             return new SongDesc { Components = [info] };
                         }

--- a/JustDanceEditor.Formats.UbiArt/Serialization/LuaTableSerializer.cs
+++ b/JustDanceEditor.Formats.UbiArt/Serialization/LuaTableSerializer.cs
@@ -6,7 +6,6 @@ using KevInc.UbiArt.FileSystem;
 using NLua;
 
 using System.Collections;
-using System.Reflection;
 using System.Text;
 using System.Text.Json;
 using System.Text.Json.Nodes;
@@ -394,88 +393,7 @@ public static partial class LuaTableSerializer
         throw new InvalidDataException("Could not extract MusicTrack from Actor_Template structure.");
     }
 
-    public static string Serialize<T>(T obj)
-    {
-        // For now, let's implement a basic LUA table generator
-        // This is complex for general objects, but we can handle our specific types
-        StringBuilder sb = new();
-        sb.AppendLine("params =");
-        SerializeObject(sb, obj, 0);
-        return sb.ToString();
-    }
-
-    private static void SerializeObject(StringBuilder sb, object? obj, int indent)
-    {
-        if (obj == null)
-        {
-            sb.Append("nil");
-            return;
-        }
-
-        string indentation = new(' ', indent * 2);
-
-        if (obj is IDictionary dict)
-        {
-            sb.AppendLine("{");
-            foreach (DictionaryEntry entry in dict)
-            {
-                sb.Append(indentation + "  ");
-                sb.Append(entry.Key + " = ");
-                SerializeObject(sb, entry.Value, indent + 1);
-                sb.AppendLine(",");
-            }
-
-            sb.Append(indentation + "}");
-        }
-        else if (obj is IEnumerable list and not string)
-        {
-            sb.AppendLine("{");
-            foreach (object? item in list)
-            {
-                sb.Append(indentation + "  ");
-                SerializeObject(sb, item, indent + 1);
-                sb.AppendLine(",");
-            }
-
-            sb.Append(indentation + "}");
-        }
-        else if (obj is string s)
-        {
-            sb.Append($"\"{s}\"");
-        }
-        else if (obj is bool b)
-        {
-            sb.Append(b ? "true" : "false");
-        }
-        else if (obj.GetType().IsPrimitive || obj is decimal || obj is float || obj is double)
-        {
-            // Use CultureInfo.InvariantCulture to ensure dot as decimal separator
-            if (obj is IConvertible conv)
-                sb.Append(conv.ToString(System.Globalization.CultureInfo.InvariantCulture));
-            else
-                sb.Append(obj.ToString());
-        }
-        else if (obj.GetType().IsClass || obj.GetType().IsValueType)
-        {
-            // Handle anonymous types or classes
-            sb.AppendLine("{");
-            foreach (PropertyInfo prop in obj.GetType().GetProperties())
-            {
-                if (prop.GetIndexParameters().Length > 0)
-                    continue; // Skip indexed properties
-                sb.Append(indentation + "  ");
-                sb.Append(prop.Name + " = ");
-                SerializeObject(sb, prop.GetValue(obj), indent + 1);
-                sb.AppendLine(",");
-            }
-
-            sb.Append(indentation + "}");
-        }
-        else
-        {
-            sb.Append(obj.ToString());
-        }
-    }
+    public static string Serialize<T>(T obj) => LuaDocumentWriter.Write(obj);
 
     private static IDictionary<string, object> LuaTableToDictionary(LuaTable table)
     {

--- a/JustDanceEditor.Formats.UbiArt/Serialization/UbiArtXmlDocumentWriter.cs
+++ b/JustDanceEditor.Formats.UbiArt/Serialization/UbiArtXmlDocumentWriter.cs
@@ -1,0 +1,129 @@
+using System.Globalization;
+using System.Reflection;
+using System.Text;
+using System.Xml;
+using System.Xml.Linq;
+
+namespace JustDanceEditor.Formats.UbiArt.Serialization;
+
+/// <summary>
+/// Small object model and serializer for UbiArt's attribute-heavy XML resources.
+/// </summary>
+public static class UbiArtXmlDocumentWriter
+{
+    public static UbiArtXmlNode Node(string name, object? attributes = null, params UbiArtXmlNode[] children) =>
+        new(name, GetAttributes(attributes), children);
+
+    public static byte[] Write(UbiArtXmlNode root)
+    {
+        XDocument document = new(new XDeclaration("1.0", "ISO-8859-1", null), ToElement(root));
+        using MemoryStream stream = new();
+        XmlWriterSettings settings = new()
+        {
+            Encoding = Encoding.Latin1,
+            Indent = true,
+            IndentChars = "\t",
+            NewLineChars = "\r\n",
+            NewLineHandling = NewLineHandling.Replace,
+            OmitXmlDeclaration = false
+        };
+        using (XmlWriter writer = XmlWriter.Create(stream, settings))
+            document.Save(writer);
+        return stream.ToArray();
+    }
+
+    public static UbiArtXmlNode Read(byte[] document)
+    {
+        using MemoryStream stream = new(document, writable: false);
+        XDocument parsed = XDocument.Load(stream);
+        return FromElement(parsed.Root ?? throw new InvalidDataException("XML document has no root element."));
+    }
+
+    public static UbiArtXmlNode Scene(IEnumerable<UbiArtXmlNode> children, bool viewFamily = false)
+        => Scene(children, new UbiArtSceneSettings(ViewFamily: viewFamily ? 1 : null));
+
+    public static UbiArtXmlNode Scene(IEnumerable<UbiArtXmlNode> children, UbiArtSceneSettings settings)
+    {
+        Dictionary<string, object?> attributes = new(StringComparer.Ordinal)
+        {
+            ["ENGINE_VERSION"] = settings.EngineVersion,
+            ["GRIDUNIT"] = settings.GridUnit,
+            ["DEPTH_SEPARATOR"] = "0",
+            ["NEAR_SEPARATOR"] = MatrixIdentity,
+            ["FAR_SEPARATOR"] = MatrixIdentity
+        };
+        if (settings.ViewFamily.HasValue)
+            attributes["viewFamily"] = settings.ViewFamily.Value;
+        if (settings.IsPopup.HasValue)
+            attributes["isPopup"] = settings.IsPopup.Value;
+
+        return Node("root", null, new UbiArtXmlNode("Scene", attributes, [.. children]));
+    }
+
+    public static UbiArtXmlNode DefaultSceneConfig() =>
+        Node("sceneConfigs", null, Node("SceneConfigs", new { activeSceneConfig = 0 }));
+
+    public static UbiArtXmlNode Actor(string type, object attributes, params UbiArtXmlNode[] children) =>
+        Node("ACTORS", new { NAME = type }, Node(type, attributes, children));
+
+    public static UbiArtXmlNode Component(string name, params UbiArtXmlNode[] content) =>
+        Node("COMPONENTS", new { NAME = name }, Node(name, null, content));
+
+    public static object StandardActorAttributes(string userFriendly, string lua, string instanceDataFile = "", string scale = "1.000000 1.000000", string position = "0.000000 0.000000") => new
+    {
+        RELATIVEZ = "0.000000",
+        SCALE = scale,
+        xFLIPPED = "0",
+        USERFRIENDLY = userFriendly,
+        POS2D = position,
+        ANGLE = "0.000000",
+        INSTANCEDATAFILE = instanceDataFile,
+        LUA = lua
+    };
+
+    private static IReadOnlyDictionary<string, object?> GetAttributes(object? attributes)
+    {
+        if (attributes == null)
+            return new Dictionary<string, object?>();
+        if (attributes is IReadOnlyDictionary<string, object?> readOnlyDictionary)
+            return readOnlyDictionary;
+        if (attributes is IDictionary<string, object?> dictionary)
+            return new Dictionary<string, object?>(dictionary, StringComparer.Ordinal);
+
+        return attributes.GetType()
+            .GetProperties(BindingFlags.Instance | BindingFlags.Public)
+            .Where(property => property.CanRead && property.GetIndexParameters().Length == 0)
+            .ToDictionary(property => property.Name, property => property.GetValue(attributes), StringComparer.Ordinal);
+    }
+
+    private static XElement ToElement(UbiArtXmlNode node)
+    {
+        XElement element = new(node.Name);
+        foreach ((string name, object? value) in node.Attributes)
+        {
+            if (value != null)
+                element.SetAttributeValue(name, Convert.ToString(value, CultureInfo.InvariantCulture));
+        }
+        foreach (UbiArtXmlNode child in node.Children)
+            element.Add(ToElement(child));
+        return element;
+    }
+
+    private static UbiArtXmlNode FromElement(XElement element) => new(
+        element.Name.LocalName,
+        element.Attributes().ToDictionary(attribute => attribute.Name.LocalName, attribute => (object?)attribute.Value, StringComparer.Ordinal),
+        [.. element.Elements().Select(FromElement)]);
+
+    private const string MatrixIdentity = "1.000000 0.000000 0.000000 0.000000, 0.000000 1.000000 0.000000 0.000000, 0.000000 0.000000 1.000000 0.000000, 0.000000 0.000000 0.000000 1.000000";
+}
+
+public sealed record UbiArtXmlNode(
+    string Name,
+    IReadOnlyDictionary<string, object?> Attributes,
+    IReadOnlyList<UbiArtXmlNode> Children);
+
+public sealed record UbiArtSceneSettings(
+    string EngineVersion = "55299",
+    string GridUnit = "0.500000",
+    int? ViewFamily = null,
+    int? IsPopup = null);

--- a/JustDanceEditor.Formats.UbiArt/UbiArtConversionStrategy.cs
+++ b/JustDanceEditor.Formats.UbiArt/UbiArtConversionStrategy.cs
@@ -73,19 +73,9 @@ public sealed class UbiArtConversionStrategy : IFormatConversionStrategy
 
     private static IEnumerable<UbiArtTargetDefinition> BuildTargets()
     {
-        yield return new UbiArtTargetDefinition(
-            new ConversionTargetDefinition(
-                FormatCode: "ubiart",
-                FormatName: "UbiArt",
-                TargetCode: "uncooked",
-                Platform: new PlatformDescriptor("pc", "PC"),
-                Version: new TargetVersionDescriptor.Custom("uncooked", "Uncooked", 10),
-                DisplayName: "Uncooked (UbiArt)",
-                ExportPrompts: [OutputFolderPrompt()],
-                Priority: 10),
-            UbiArtPlatform.Uncooked,
-            UbiArtEngineVersion.JD2022,
-            CookedType.Uncooked);
+        yield return CreateUncookedTarget("uncooked-2014", "JD2014 Uncooked", UbiArtEngineVersion.JD2014, 2014);
+        yield return CreateUncookedTarget("uncooked-2015", "JD2015 Uncooked", UbiArtEngineVersion.JD2015, 2015);
+        yield return CreateUncookedTarget("uncooked-modern", "Modern Uncooked", UbiArtEngineVersion.JD2022, 2022);
 
         foreach (int year in new[] { 2014, 2015, 2016, 2017, 2018, 2019, 2020 })
             yield return CreateVersionedTarget($"wii-{year}", "wii", "Revolution (Wii)", UbiArtPlatform.Revolution, ToEngineVersion(year), year);
@@ -127,6 +117,23 @@ public sealed class UbiArtConversionStrategy : IFormatConversionStrategy
             platform,
             engineVersion,
             CookedType.Cooked);
+    }
+
+    private static UbiArtTargetDefinition CreateUncookedTarget(string targetCode, string displayName, UbiArtEngineVersion engineVersion, int year)
+    {
+        return new UbiArtTargetDefinition(
+            new ConversionTargetDefinition(
+                FormatCode: "ubiart",
+                FormatName: "UbiArt",
+                TargetCode: targetCode,
+                Platform: new PlatformDescriptor("pc", "PC"),
+                Version: new TargetVersionDescriptor.Custom(year.ToString(), $"JD{year}", year),
+                DisplayName: displayName,
+                ExportPrompts: [OutputFolderPrompt()],
+                Priority: 10),
+            UbiArtPlatform.Uncooked,
+            engineVersion,
+            CookedType.Uncooked);
     }
 
     private static ConversionPrompt OutputFolderPrompt() =>

--- a/JustDanceEditor.Formats.UbiArt/UbiArtJdiFormat.cs
+++ b/JustDanceEditor.Formats.UbiArt/UbiArtJdiFormat.cs
@@ -166,7 +166,7 @@ public sealed class UbiArtJdiFormat(ISongDataLoader songDataLoader, Func<UbiArtC
 
         string songName = importResult.Package.Metadata.MapName ?? importResult.Package.Metadata.Title ?? "song";
         string platformName = ubiRequest.ExportPlatform == UbiArtPlatform.Uncooked
-            ? "uncooked"
+            ? $"uncooked_{(int)ubiRequest.ExportEngineVersion}"
             : ubiRequest.ExportPlatform.GetCookedFolderName();
         string folderName = $"{songName.ToLowerInvariant()}_{platformName}";
         bool exportIntoGameFolder = UbiArtGameFolderIpkExporter.LooksLikeGameFolder(ubiRequest.OutputPath, ubiRequest.ExportPlatform);


### PR DESCRIPTION
#### PR Classification
Major refactor and modernization of the UbiArt uncooked export pipeline to support version-specific layouts, robust serialization, and improved maintainability.

#### PR Summary
This PR introduces object-based Lua and XML serialization for uncooked UbiArt exports, adds version-specific uncooked targets, and improves resource generation and test coverage.
- UncookedEngineContentGenerator: Replaced string-based Lua generation with object-based serialization and added support for JD2014/JD2015/Modern layouts.
- UbiArtXmlDocumentWriter & LuaDocumentWriter: Added new serializers for XML and Lua, used throughout resource generation.
- SongDataLoader & LuaTableSerializer: Improved uncooked tape resolution and normalized Lua entry tables for robust deserialization.
- UbiArtAssetWriter: Updated asset writing logic for uncooked platforms, including phone textures, gesture folders, and raw video handling.
- UbiArtConversionStrategy & related tests: Added three versioned uncooked export targets and comprehensive tests for new serialization and resource logic.
